### PR TITLE
Feature/net style updates

### DIFF
--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -69,11 +69,12 @@ export class NetworkEditor extends Component {
         this.cy.add(result.network.elements);
       }
 
+      const minQVal = this.getMinQValue();
       const maxQVal = this.getMaxQValue();
       this.cy.data({ parameters: result.parameters, maxQVal });
 
       // Set network style
-      this.cy.style().fromJson(DEFAULT_NETWORK_STYLE(maxQVal));
+      this.cy.style().fromJson(DEFAULT_NETWORK_STYLE(minQVal, maxQVal));
 
       // Notify listeners that the network has been loaded
       console.log('Loaded');
@@ -148,15 +149,12 @@ export class NetworkEditor extends Component {
     });
   }
 
+  getMinQValue() {
+    return this.cy.nodes().min(n => n.data('padj')).value;
+  }
+
   getMaxQValue() {
-    return this.cy.nodes().reduce(
-      (prevVal, node) => {
-        if(typeof prevVal === 'undefined')
-          return 0;
-        const qval = node.data('padj');
-        return qval ? Math.max(qval, prevVal) : prevVal;
-      }
-    );
+    return this.cy.nodes().max(n => n.data('padj')).value;
   }
 
   getClusterLabels(result) {

--- a/src/client/components/network-editor/legend.js
+++ b/src/client/components/network-editor/legend.js
@@ -31,7 +31,7 @@ function createCy(maxQVal) {
     panningEnabled: false,
 
     style: [ 
-      ...DEFAULT_NETWORK_STYLE(0.1),
+      ...DEFAULT_NETWORK_STYLE(0.1, 0.2),
       { selector: 'node',
         style: {
           'width': 25,
@@ -46,7 +46,9 @@ function createCy(maxQVal) {
           'border-opacity': 0,
           'width': 1,
           'text-valign': 'center',
-          'text-halign': 'right'
+          'text-halign': 'right',
+          'color': '#000',
+          'text-outline-opacity': 0
       }},
       { selector: 'node[hidden]', 
         style: {
@@ -72,7 +74,7 @@ function createCy(maxQVal) {
 
       { data: { id: 'b', padj: 0.1 } },
       { data: { id: 'b-lab', label: 'Node Color:' } },
-      { data: { id: 'b-exp', label: `q-value, white (0.0) to red (${maxQVal.toFixed(2)})` } },
+      { data: { id: 'b-exp', label: `q-value, brighter is more sig.` } },
 
       { data: { id: 'e-source', hidden: true } },
       { data: { id: 'e-target', hidden: true } },

--- a/src/client/components/network-editor/main.js
+++ b/src/client/components/network-editor/main.js
@@ -248,7 +248,8 @@ const Main = ({ controller, showControlPanel, drawerVariant, onContentClick }) =
 
     const updateSelectionClass = _.debounce(() => {
       const allEles = cy.elements();
-      const selectedEles = allEles.filter(':selected');
+      const targetEle = allEles.filter(':selected'); // 1 ele
+      const selectedEles = targetEle.isNode() ? targetEle.closedNeighborhood() : targetEle.add(targetEle.connectedNodes());
       const unselectedEles = allEles.subtract(selectedEles);
 
       cy.batch(() => {

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 
 export const NODE_BG_COLOR = {
   start: '#3baa71', // best nodes (low p-val)

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -91,6 +91,14 @@ export const DEFAULT_NETWORK_STYLE = (minQVal, maxQVal) => [
     }
   },
   {
+    selector: 'node:selected',
+    style: {
+      'border-width': 6,
+      'border-color': '#aadafa',
+      'border-opacity': 0.666
+    }
+  },
+  {
     selector: 'node.eh-preview',
     style: {
       'overlay-opacity': 0.2

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -1,36 +1,44 @@
 
 export const NODE_BG_COLOR = {
-  start: 'rgb(239,138,98)',
-  end: 'rgb(178,24,43)'
+  start: '#3baa71', // best nodes (low p-val)
+  end: '#72877c' // worst nodes
 };
 
-export const DEFAULT_NETWORK_STYLE = (maxQVal) => [
+const nodeLabel = _.memoize(node => {
+  const text = node.data('label') ?? node.data('name');
+  const percent = text.indexOf('%');
+
+  if (percent > 0) {
+    return text.substring(0, percent).toLowerCase();
+  } else {
+    return text;
+  }
+}, node => node.id());
+
+export const DEFAULT_NETWORK_STYLE = (minQVal, maxQVal) => [
   {
     selector: 'node',
     style: {
-      'opacity': 0.8,
-      'border-color': '#333333',
-      'border-width': 1,
+      'opacity': 1,
+      'border-width': 0,
       'border-opacity': 0.7,
-      'label': 'data(name)',
+      'label': nodeLabel,
       'width':  40, //ele => ele.data('gs_size') / 10,
       'height': 40, // ele => ele.data('gs_size') / 10,
-      'font-size': '6px',
+      'font-size': '8px',
       'text-valign': 'center',
       'text-wrap': 'wrap',
       'text-max-width': 80,
-    }
-  },
-  {
-    selector: 'node[label]',
-    style: {
-      'label': 'data(label)', // If there's a 'label' attribute, that overrides the 'name' attribute
+      'text-outline-width': 1.5,
+      'text-outline-opacity': 1,
+      'color': '#fff'
     }
   },
   {
     selector: 'node[padj]',
     style: {
-      'background-color': `mapData(padj, 0.0, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`,
+      'background-color': `mapData(padj, ${minQVal || 0}, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`,
+      'text-outline-color': `mapData(padj, ${minQVal || 0}, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`
     }
   },
   {
@@ -38,15 +46,17 @@ export const DEFAULT_NETWORK_STYLE = (maxQVal) => [
     style: {
       'width':  60, //ele => ele.data('gs_size') / 10,
       'height': 60, // ele => ele.data('gs_size') / 10,
-      'background-color': 'gray'
+      'background-color': 'gray',
+      'text-outline-color': 'gray'
     }
   },
   {
     selector: 'edge',
     style: {
-      'line-color' : '#a6cee3', //'#404040',
+      'line-color' : '#b1d6d8',
       'line-opacity': 0.6,
-      'curve-style': 'bezier',
+      'curve-style': 'haystack',
+      'haystack-radius': 0,
       'width': ele => ele.data('similarity_coefficient') * 6,
     }
   },
@@ -63,6 +73,9 @@ export const DEFAULT_NETWORK_STYLE = (maxQVal) => [
       'border-color': '#2B65EC',
       'font-size': '24px',
       'text-valign':'top',
+      'text-outline-width': 0,
+      'text-outline-opacity': 0,
+      'color': '#000'
     }
   },
   {


### PR DESCRIPTION
**General information**

Associated issues: 

- #20 
- #28

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] N/A:  Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

This updates the style from changes in the [experimental circular cluster branch](https://github.com/cytoscape/enrichment-map-webapp/tree/feature/circle-cluster-exp).

- The nodes are green.
  - Brighter nodes have better p-values.
  - The variance of the scores is more visible.
  - The summary nodes are currently unchanged -- still grey.
- The labels are much better.
  - No weird `BLAH BLAH BLAH % JUNK` labels.  The `% JUNK` is removed.
  - Labels are lower case.
  - Labels have the outline style that most people like in their figures. 
  - Labels are a bit bigger.
- Selection styling is much improved.
  - Show relevant context in the network.  If you click a node, show what nodes and edges it's connected to.  If you click an edge, show the connected nodes.
  - Highlight the particular node you clicked, so that it's visually distinct from its neighbourhood. 