### PR TITLE
Compact sidebar

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -107,13 +107,32 @@ const useStyles = makeStyles((theme) => ({
   },
   rankBarText: {
     position: "absolute",
-    left: 0,
     top: 0,
     fontSize: "0.8em",
-    marginLeft: "0.25em",
-    color: "#333"
+    color: "#999",
+    mixBlendMode: 'difference',
+    marginLeft: '0.125em',
+    marginRight: '0.125em'
   }
 }));
+
+const rankBarTextStyle = (rank, minRank, maxRank) => {
+  if (minRank > 0 && maxRank > 0) { // all positive => bars start at left and go right
+    return { left: 0 };
+  } else if (minRank < 0 && maxRank < 0) { // all negative => bars start at right and go left
+    return { right: 0 };
+  } else if (rank < 0) { // neg. rank should be shifted right by the size of the pos. max. bar size
+    let offset = Math.abs(maxRank) / (Math.abs(minRank) + Math.abs(maxRank)) * 100;
+
+    return {
+      right: `${offset}%`
+    };
+  } else { // pos. rank should be shifted left by the size of the neg. max. bar size
+    let offset = Math.abs(minRank) / (Math.abs(minRank) + Math.abs(maxRank)) * 100;
+
+    return { left: `${offset}%` };
+  }
+};
 
 const GeneMetadataPanel = ({ symbol, rank }) => {
   const classes = useStyles();
@@ -217,13 +236,13 @@ const GeneListPanel = ({ controller, genes, selectedGene, setSelectedGene }) => 
     setSelectedGene(selectedGene !== symbol ? symbol : null);
   };
 
+  const { minRank, maxRank } = controller;
+
   const renderGeneRow = ({ symbol, rank, idx }) => {
     let data;
 
     if (rank) {
       data = [];
-      const minRank = controller.minRank;
-      const maxRank = controller.maxRank;
       
       if (rank < 0) {
         // Low regulated genes
@@ -286,7 +305,7 @@ const GeneListPanel = ({ controller, genes, selectedGene, setSelectedGene }) => 
                     data && (
                       <div className={classes.rankBarParent}>
                         <HSBar data={data} height={CHART_HEIGHT} />
-                        <span className={classes.rankBarText}>{roundedRank}</span>
+                        <span className={classes.rankBarText} style={rankBarTextStyle(rank, minRank, maxRank)}>{roundedRank}</span>
                       </div>
                     )
                   }


### PR DESCRIPTION

**General information**

This PR has improvements to the readability of the gene info in the sidebar.

Associated issues:

- #16

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] N/A: Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Round the rank to 2 digits after the decimal point.  Use `GENE_RANK_ROUND_DIGITS` to configure.
- Include the rank number on the bar.  This makes it clear that the number represents the same value as the bar.  It also saves a lot of space so you can see more genes without scrolling.
- The caret to expand and collapse a gene is softened.  This makes the gene name stand out more, making it easier to read the list.
- This uses inlines styles, since it looks like the sidebar is going that way.

Before:

<img width="314" alt="genes-before" src="https://user-images.githubusercontent.com/989043/197841899-5579118c-584a-4b9c-a7cf-8b850fc5c132.png">

After:

<img width="315" alt="genes-after" src="https://user-images.githubusercontent.com/989043/197841916-dc294e8c-1ecf-499b-aab4-07a0662042d6.png">
