### PR TITLE
Set the zoom range dynamically

### DIFF
--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -70,6 +70,10 @@ export class NetworkEditorController {
       this.layout.stop();
     }
 
+    // unrestricted zoom, since the old restrictions may not apply if things have changed
+    this.cy.minZoom(-1e50);
+    this.cy.maxZoom(1e50);
+
     this.layout = this.cy.layout({
       name: 'cose',
       idealEdgeLength: edge => 50 - 40 * (edge.data('similarity_coefficient')),
@@ -111,6 +115,10 @@ export class NetworkEditorController {
     }).run();
 
     this.cy.fit(DEFAULT_PADDING);
+
+    // now that we know the zoom level when the graph fits to screen, we can use restrictions
+    this.cy.minZoom(this.cy.zoom() * 0.25);
+    this.cy.maxZoom(3);
   }
 
   /**


### PR DESCRIPTION
**General information**

Restrict the zoom bounds so it's harder for the user to lose their place.

Associated issues: #52

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**


https://user-images.githubusercontent.com/989043/205960022-8425d0d5-6acf-4d02-9efc-17cfb431000f.mov



- This ensures that the zoom restrictions still work on large networks.
- The zoom restrictions are applied after running the layout.
- Max zoom: always 2 (i.e. 2x the stylesheet values)
- Min zoom: 0.25x the zoom level of the fit-to-screen layout
- Closes #52
