### PR TITLE
Use log mapping of node colour

### DIFF
--- a/src/client/components/network-editor/legend.js
+++ b/src/client/components/network-editor/legend.js
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function createCy(maxQVal) {
+function createCy() {
   const cy = new Cytoscape({
     headless: true,
     styleEnabled: true,
@@ -135,8 +135,7 @@ export function StyleLegend({ controller, width, height }) {
 
   useEffect(() => {
     if (!loading) {
-      const maxQVal = controller.cy.data('maxQVal');
-      cyRef.current = createCy(maxQVal); 
+      cyRef.current = createCy(); 
     }
   }, [loading]); 
 

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -36,10 +36,10 @@ export const DEFAULT_NETWORK_STYLE = (minQVal, maxQVal) => [
     }
   },
   {
-    selector: 'node[padj]',
+    selector: 'node[padjLog]',
     style: {
-      'background-color':   `mapData(padj, ${minQVal || 0}, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`,
-      'text-outline-color': `mapData(padj, ${minQVal || 0}, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`
+      'background-color':   `mapData(padjLog, ${minQVal || 0}, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`,
+      'text-outline-color': `mapData(padjLog, ${minQVal || 0}, ${maxQVal || 1.0}, ${NODE_BG_COLOR.start}, ${NODE_BG_COLOR.end})`
     }
   },
   // {


### PR DESCRIPTION
**General information**

Use a log scale for node colour.

Associated issues: 

- #48

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] N/A: Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Create a `padjLog` field in the node data that can be used for log mapping.
- The stylesheet just uses this value instead of `padj`.

Before (nodes sorted by q-value) on brca_hd_tep_ranks_100.rnk:

<img width="865" alt="Screen Shot 2022-12-06 at 15 15 20" src="https://user-images.githubusercontent.com/989043/206014631-580994c1-6586-4d7b-b96f-56ba628ffe5c.png">

After (nodes sorted by q-value):

<img width="867" alt="Screen Shot 2022-12-06 at 15 15 00" src="https://user-images.githubusercontent.com/989043/206014706-001136f5-fdc4-44af-9b0e-3f0282b9ff94.png">

This helps to identify the top nodes a bit better in a FD layout (with log scaling):

<img width="643" alt="Screen Shot 2022-12-06 at 15 22 11" src="https://user-images.githubusercontent.com/989043/206014837-feb8d607-b1d3-4fc5-b983-72e6181142fb.png">
