### PR TITLE
Feedback: Errors & UI warnings

### DIFF
--- a/src/client/components/home/data-file-reader.js
+++ b/src/client/components/home/data-file-reader.js
@@ -1,5 +1,6 @@
 import LineReader from 'browser-line-reader';
 import * as XLSX from "xlsx";
+import { NumberOfColumnsError } from '../../../model/errors';
 
 /**
  * EM app code that does the same thing...
@@ -76,6 +77,9 @@ export function readTSVFile(file, delimiter = '\t') {
         if(header.type == 'error') {
           lineReader.emit('error', 'File format error: cannot determine the number of data columns.');
           return;
+
+          // e.g. 
+          // throw new NumberOfColumnsError(header.columns);
         }
         columns = header.columns;
         type = header.type;

--- a/src/model/errors.js
+++ b/src/model/errors.js
@@ -1,26 +1,105 @@
-/**
- * A `DocumentNotFoundError` is thrown when a `JsonSyncher` is not stored in the database and
- * a read operation fails.
- */
-export class DocumentNotFoundError extends Error {
-  constructor(dbName, docId, message){
-    super(`The document in database '${dbName}' with ID '${docId}' could not be found` + (message ? `: ${message}` : ''));
+export class QueryError extends Error {
+  static name = 'QueryError';
 
-    this.dbName = dbName;
-    this.docId = docId;
+  constructor(message) {
+    super(message ?? 'A query error occurred.'); // TODO: better default message
+
+    this.name = QueryError.name;
+  }
+
+  static fromJSON(json) {
+    const { name, message } = json;
+
+    switch (name) {
+      case QueryError.name:
+        return new QueryError(message);
+      case NumberOfColumnsError.name:
+        return NumberOfColumnsError.fromJSON(json);
+      case GeneLookupError.name:
+        return GeneLookupError.fromJSON(json);
+      case NonNumericValueError.name:
+        return NonNumericValueError.fromJSON(json);
+      // TODO: add new validation error types here
+    }
+  }
+
+  json() {
+    return {
+      name: this.name,
+      message: this.message
+    };
   }
 }
 
-/**
- * A `LoadConflictError` is thrown when a `JsonSyncher` has conflicting revisions on load.
- */
-export class LoadConflictError extends Error {
-  constructor(dbName, docId, rev, conflictingRevs){
-    super(`The document in database '${dbName}' with ID '${docId}' and revision '${rev}' has conflicting revisions '[${conflictingRevs.join(', ')}]'`);
+export class GeneLookupError extends QueryError {
+  static name = 'GeneLookupError';
 
-    this.dbName = dbName;
-    this.docId = docId;
-    this.rev = rev;
-    this.conflictingRevs = conflictingRevs;
+  constructor(genes, message) {
+    super(message ?? 'Several genes are invalid.'); // TODO: better default message
+
+    this.name = GeneLookupError.name;
+    this.genes = genes; // in format { row, column, name }
+  }
+
+  static fromJSON(json) {
+    return new GeneLookupError(json.genes, json.message);
+  }
+
+  json() {
+    return {
+      name: this.name,
+      message: this.message,
+      genes: this.genes
+    };
+  }
+}
+
+export class NumberOfColumnsError extends QueryError {
+  static name = 'NumberOfColumnsError';
+ 
+  constructor(columns, message) {
+    super(message ?? 'The number of columns is wrong!'); // TODO: better default message
+
+    this.name = NumberOfColumnsError.name;
+    this.columns = columns;
+  }
+
+  static fromJSON(json) {
+    return new NumberOfColumnsError(json.columns, json.message);
+  }
+
+  json() {
+    return {
+      name: this.name,
+      message: this.message,
+      columns: this.columns
+    };
+  }
+}
+
+export class NonNumericValueError extends QueryError {
+  static name = 'NonNumericValueError';
+
+  constructor(value, column, row, message) {
+    super(message ?? `Non-numeric value in input file at ${column}:${row} with value '${value}'.`);
+
+    this.name = NonNumericValueError.name;
+    this.value = value;
+    this.column = column;
+    this.row = row;
+  }
+
+  static fromJSON(json) {
+    return new NonNumericValueError(json.value, json.column, json.row, json.message);
+  }
+
+  json() {
+    return {
+      name: this.name,
+      message: this.message,
+      value: this.value,
+      column: this.column,
+      row: this.row
+    };
   }
 }


### PR DESCRIPTION
**General information**

This is a PR for discussion re. error handling.  It is not currently to be considered for merging.

Associated issues: 

- #46 

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

(1) Goal:  Enable us to show clear feedback to users when there is a problem with their input data.
  - Approach:  Use [a number of error (exception) classes](https://github.com/cytoscape/enrichment-map-webapp/blob/2467b34de1b25b5c59d47ffc7764422aa1096e42/src/model/errors.js).
  - Approach:  The error classes should each contain enough information for the UI to show clear feedback.  The UI should determine how and what to display, and the error objects should just have context.
  - Example:  Joe has an invalid cell in his input spreadsheet.  The cell should have a number, but it doesn't.  There are several types of feedback Joe could be given, depending on the design:
    - (A) Joe sees just a text message, e.g. 'your file has incorrectly formatted numbers'.
    - (B) Joe gets a descriptive text message, e.g. 'your file has an incorrect number at cell C12'.
    - (C) Joe gets a descriptive text message and also a nice visual summary of the incorrect cells, like an abbreviated view of the spreadsheet with the incorrect cells in red.
  - Discussion:  What changes to the errors should we make?  We currently just have a rough draft, so we should consider the following:
    - What other error types should we consider?
    - What data (context) should go in each one?
    - Should we have something like a `ManyErrors` class that can reference multiple errors without losing the general exception context (e.g. as may be used to facilitate example C)?
    - Other considerations

(2) Goal:  Unify the way that errors are handled in the services and the UI to facilitate (1).
  - Approach:  The services should return JSON error objects that correspond to serialised JSON of applicable error classes.
  - Approach:  The base query error class has a static factory function that can be used to generate the correct subtype error object, allowing the services to just send JSON back (rather than error message strings). 

(3) Goal:  Balance the amount of information (e.g. number of errors) shown to users at once.
  - Discussion:  We'll need to decide what balance to strike:
    - Showing many simultaneous errors v.s. showing one at a time (or one type at a time)
    - Example files as feedback
    - Excel file as feedback
    - Considering the number of times a user would have to edit and re-upload
