### PR TITLE
Drag & drop GCT fix & discussion

### DIFF
--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -30,7 +30,7 @@ const STEP = {
 };
 
 const FILE_EXT_REGEX = /\.[^/.]+$/;
-const TSV_EXTS = ['txt', 'TXT', 'rnk', 'RNK', 'tsv', 'TSV'];
+const TSV_EXTS = ['txt', 'TXT', 'rnk', 'RNK', 'tsv', 'TSV', 'gct', 'GCT'];
 const EXCEL_EXTS = ['xls', 'XLS', 'xlsx', 'XLSX'];
 
 // globally cached

--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -277,7 +277,7 @@ export class Content extends Component {
           </Grid>
         </Grid>
         <p className={classes.tagline}>Get a quick-and-easy, publication-ready enrichment figure for your two-case RNA-Seq experiment.</p>
-        <InfoPanel />
+        {/* <InfoPanel /> */}
         <Button className={classes.uploadButton} onClick={e => this.onClickUpload(e)} variant="contained" color="primary">Upload RNA-Seq data</Button>
       </div>
     );


### PR DESCRIPTION
**General information**

This fixes GCT files in the drag-and-drop feature.  **This is not yet mergeable, as we need to discuss what approach we use in the short term.  There are trade-offs.**

Associated issues:

- #59 

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [x] N/A: Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- This allows GCT files to be uploaded both by the button and the drag-and-drop feature.
- It turns out that all file types were affected by the bug described in #59.  Dropping any file resulted in the browser showing the raw file in a new tab (Chrome) or ignoring the file (Safari).
- The simple part of the fix is to include the `GCT` extension in the `TSV_EXTS` whitelist (596f135d299418f6faf469691632a263f9beeabf).
- The complex part is that the carousel that describes the app on the front page interferes with drag-and-drop.  In this PR, the `InfoPanel` is temporarily disabled to demonstrate this effect (29124b0519938d3c3ba01dd4ebc97118ab526c01).  
  - You can revert [this line](https://github.com/cytoscape/enrichment-map-webapp/commit/29124b0519938d3c3ba01dd4ebc97118ab526c01#diff-3086653e53ac2482ebef2152887e41814f7646ee8d2aa49954a038547a7fb99bR280) to verify that the `InfoPanel` carousel conflicts with the drag-and-drop feature.  
  - Some approaches we could use short-term:
    - Disable `InfoPanel` for now.  That would be a shame, but it would be a quick, cheap fix.
    - Refactor the `InfoPanel` so it doesn't use conflicting UI components.  I strongly suspect that the Material Component for the carousel hijacks the top-level browser events needed for any drag-and-drop feature to work.  Using a scrollable list of images would very likely be a workaround.
    - The carousel component might have a suitable configuration so that it doesn't conflict.
    - Any other suggestions?
