### PR TITLE
Send messages from services to sentry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following environment variables can be used to configure the server:
 - `EM_SERVICE_URL`: the pull path of the [Java service](https://github.com/cytoscape/enrichmentmap-service) (i.e. for a query, not the root URL)
 - `MONGO_ROOT_NAME`: the name of the app's DB in Mongo
 - `MONGO_COLLECTION_QUERIES`: the name of the query collection
+- `SENTRY_ENVIRONMENT`: the Sentry environment name to use (automatic in prod mode, set to `test*` like `test_joe` to get Sentry reports in debug instances)
 
 ## Run targets
 

--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -6,7 +6,7 @@ import ClassSelector from './class-selector';
 import { InfoPanel } from './info-panel';
 import { DebugMenu } from '../../debug-menu';
 
-import { PROD } from '../../env';
+import { SENTRY } from '../../env';
 
 import { withStyles } from '@material-ui/core/styles';
 
@@ -41,13 +41,12 @@ let sampleExpressionFiles = [];
 class NondescriptiveHandledError extends Error { // since we don't have well-defined errors
   constructor(message) {
     message = message ?? 'A non-descriptive error occurred.  Check the attached file.';
-
     super(message);
   }
 }
 
 const captureNondescriptiveErrorInSentry = (errorMessage) => {
-  if (PROD) {
+  if (SENTRY) {
     Sentry.captureException(new NondescriptiveHandledError(errorMessage));
     console.error('Reporting browser error to Sentry: ' + errorMessage);
   }
@@ -146,7 +145,7 @@ export class Content extends Component {
     const name = file.name.replace(FILE_EXT_REGEX, '');
     const ext = file.name.split('.').pop();
 
-    if (PROD) {
+    if (SENTRY) {
       const attachmentName = file.name;
       const attachmentContentType = file.type;
       const arrayBuffer = await file.arrayBuffer();

--- a/src/client/env.js
+++ b/src/client/env.js
@@ -10,6 +10,9 @@
  */
 
 export const NODE_ENV = process.env.NODE_ENV;
-export const PROD = NODE_ENV === 'production';
 export const PORT = parseInt(process.env.PORT, 10);
 export const NDEX_API_URL = process.env.NDEX_API_URL;
+
+// Sentry config
+export const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT;
+export const SENTRY = NODE_ENV === 'production' || (SENTRY_ENVIRONMENT && SENTRY_ENVIRONMENT.startsWith('test'));

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,16 +8,17 @@ import { registerCytoscapeExtensions } from '../model/cy-extensions';
 import { fixOldFashionedScrollStyle } from './scroll';
 import * as Sentry from "@sentry/browser";
 import { BrowserTracing } from "@sentry/tracing";
-import { PROD } from './env';
+import { SENTRY, SENTRY_ENVIRONMENT } from './env';
 
 if( debug.enabled() ){
   debug.init();
 }
 
-if (PROD) {
+if (SENTRY) {
   Sentry.init({
     dsn: "https://996aac9eb02a4419b5e7babe8163696e@o4504571938603008.ingest.sentry.io/4504572057812992",
     integrations: [new BrowserTracing()],
+    environment: SENTRY_ENVIRONMENT,
   
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.

--- a/src/server/env.js
+++ b/src/server/env.js
@@ -3,21 +3,28 @@
  *
  * Default values are specified in /.env
  *
- * You can normalise the values (e.g. with `parseInt()`, as all env vars are
- * strings).
+ * You can normalise the values (e.g. with `parseInt()`, as all env vars are strings).
  */
 
+
+// Node/Express config
 export const NODE_ENV = process.env.NODE_ENV;
-export const PROD = NODE_ENV === 'production';
 export const PORT = parseInt(process.env.PORT, 10);
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 export const BASE_URL = process.env.BASE_URL;
 export const UPLOAD_LIMIT = process.env.UPLOAD_LIMIT;
-export const NDEX_API_URL = process.env.NDEX_API_URL;
-export const MONGO_URL = process.env.MONGO_URL;
-export const MONGO_ROOT_NAME = process.env.MONGO_ROOT_NAME;
-export const MONGO_COLLECTION_QUERIES = process.env.MONGO_COLLECTION_QUERIES;
+export const TESTING = ('' + process.env.TESTING).toLowerCase() === 'true';
+
+// Microservice config
 export const FGSEA_PRERANKED_SERVICE_URL = process.env.FGSEA_PRERANKED_SERVICE_URL;
 export const FGSEA_RNASEQ_SERVICE_URL =  process.env.FGSEA_RNASEQ_SERVICE_URL;
 export const EM_SERVICE_URL = process.env.EM_SERVICE_URL;
-export const TESTING = ('' + process.env.TESTING).toLowerCase() === 'true';
+
+// Mongo config
+export const MONGO_URL = process.env.MONGO_URL;
+export const MONGO_ROOT_NAME = process.env.MONGO_ROOT_NAME;
+export const MONGO_COLLECTION_QUERIES = process.env.MONGO_COLLECTION_QUERIES;
+
+// Sentry config
+export const SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT;
+export const SENTRY = NODE_ENV === 'production' || (SENTRY_ENVIRONMENT && SENTRY_ENVIRONMENT.startsWith('test'));


### PR DESCRIPTION
refs #69

**General information**

Associated issues: #69

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] N/A : Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

Pull request does the following...
- Renames the PROD env var to SENTRY, and adds a SENTRY_ENVIRONMENT variable, because you may want to test sentry in non-production environments.
- Adds code to the express endpoint that gathers diagnostic messages from the FGSEA service and forwards them to sentry.
- Fixes a major issue with sentry evets getting dropped because the payload was too large. This can easily happen because we send a lot of data from the client to the server.
