### PR TITLE
Feature/gene scroll reset

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -259,9 +259,10 @@ const GeneListPanel = ({ controller, genes, sort }) => {
   const classes = useStyles();
   const virtuoso = useRef(null);
   
+  // Resets the scroll position when either the gene list or the sort has changed
   useEffect(() => {
     setResetScroll(true);
-  }, [sort]);
+  }, [genes, sort]);
 
   useEffect(() => {
     if (resetScroll) {

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -269,7 +269,7 @@ const GeneListPanel = ({ controller, genes, sort }) => {
       virtuoso.current.scrollToIndex({
         index: 0,
         align: 'center',
-        behavior: 'smooth',
+        behavior: 'auto',
       });
     }
   });

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { useQuery } from "react-query";
@@ -253,11 +253,28 @@ const GeneMetadataPanel = ({ symbol, showSymbol }) => {
   );
 };
 
-const GeneListPanel = ({ controller, genes }) => {
+const GeneListPanel = ({ controller, genes, sort }) => {
   const [selectedGene, setSelectedGene] = useState(null);
+  const [resetScroll, setResetScroll] = useState(true);
   const classes = useStyles();
+  const virtuoso = useRef(null);
+  
+  useEffect(() => {
+    setResetScroll(true);
+  }, [sort]);
+
+  useEffect(() => {
+    if (resetScroll) {
+      virtuoso.current.scrollToIndex({
+        index: 0,
+        align: 'center',
+        behavior: 'smooth',
+      });
+    }
+  });
 
   const toggleGeneDetails = async (symbol) => {
+    setResetScroll(false);
     setSelectedGene(selectedGene !== symbol ? symbol : null);
   };
 
@@ -373,6 +390,7 @@ const GeneListPanel = ({ controller, genes }) => {
   
   return (
     <Virtuoso
+      ref={virtuoso}
       totalCount={totalGenes}
       itemContent={idx => renderGeneRow(idx)}
       overscan={200}
@@ -387,6 +405,7 @@ GeneMetadataPanel.propTypes = {
 GeneListPanel.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController).isRequired,
   genes: PropTypes.array,
+  sort: PropTypes.string,
 };
 
 export default GeneListPanel;

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -268,7 +268,6 @@ const GeneListPanel = ({ controller, genes, sort }) => {
     if (resetScroll) {
       virtuoso.current.scrollToIndex({
         index: 0,
-        align: 'center',
         behavior: 'auto',
       });
     }

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -320,7 +320,7 @@ const LeftDrawer = ({ controller, open, isMobile }) => {
           </div>
           <div className={classes.drawerSection}>
             {networkLoaded && geneListIndexed && (
-              <GeneListPanel controller={controller} genes={genes} />
+              <GeneListPanel controller={controller} genes={genes} sort={sort} />
             )}
           </div>
           <div className={classes.drawerFooter}>


### PR DESCRIPTION
**General information**

Associated issues: #86

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Clicking a sort button (UP/DOWN) now resets the gene list scroll to the first item.
- Searching genes and clearing the search also reset the scroll.
- Clicking a gene to expand the item (description, linkouts) should **not** reset the scroll.
