### PR TITLE
Feature/new share menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "fready": "^1.0.0",
         "gaussian": "^1.2.0",
         "http-proxy-middleware": "^0.19.1",
+        "jszip": "^3.10.1",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
         "material-ui-dropzone": "^3.5.0",
@@ -4430,8 +4431,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -8297,6 +8297,25 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/keycode": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
@@ -9914,8 +9933,7 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/papaparse": {
       "version": "5.3.2",
@@ -11459,8 +11477,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -12171,7 +12188,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -12186,7 +12202,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -12809,8 +12824,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -18939,8 +18953,7 @@
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cose-base": {
       "version": "1.0.3",
@@ -21920,6 +21933,27 @@
         "object.assign": "^4.1.3"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "lie": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+          "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+          "requires": {
+            "immediate": "~3.0.5"
+          }
+        }
+      }
+    },
     "keycode": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
@@ -23187,8 +23221,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "papaparse": {
       "version": "5.3.2",
@@ -24157,8 +24190,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -24728,7 +24760,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -24743,7 +24774,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -25242,8 +25272,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "fready": "^1.0.0",
     "gaussian": "^1.2.0",
     "http-proxy-middleware": "^0.19.1",
+    "jszip": "^3.10.1",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
     "material-ui-dropzone": "^3.5.0",

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -10,7 +10,7 @@ import { ShareMenu } from './share-panel';
 
 import { withStyles } from '@material-ui/core/styles';
 
-import { AppBar, Snackbar, Toolbar } from '@material-ui/core';
+import { AppBar, Button, Snackbar, SnackbarContent, Toolbar } from '@material-ui/core';
 import { Divider } from '@material-ui/core';
 import { Popover, Menu, MenuItem} from "@material-ui/core";
 import { Tooltip } from '@material-ui/core';
@@ -21,6 +21,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import FitScreenIcon from '@material-ui/icons/SettingsOverscan';
 import ReplyIcon from '@material-ui/icons/Reply';
 import MoreIcon from '@material-ui/icons/MoreVert';
+import CloseIcon from '@material-ui/icons/Close';
 
 const MOBILE_MENU_ID = "menu-mobile";
 const SHARE_MENU_ID = "menu-share";
@@ -95,7 +96,7 @@ export class Header extends Component {
       this.showMenu(SHARE_MENU_ID, event.currentTarget);
     };
 
-    const showSnackbar = (open, message ) => {
+    const showSnackbar = (open, message='') => {
       this.setState({ snackOpen: open, snackMessage: message });
     };
 
@@ -128,13 +129,23 @@ export class Header extends Component {
     
     return (
       <>
-        <Snackbar 
-          style={{zIndex: 100}} 
+        <Snackbar
+          className={classes.snackBar}
+          anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
           open={this.state.snackOpen} 
           autoHideDuration={4000} 
-          onClose={() => showSnackbar(false, "")} 
-          message={this.state.snackMessage}
-        />
+          onClose={() => showSnackbar(false)} 
+        >
+          <SnackbarContent 
+            className={classes.snackBarContent}
+            message={<span>{this.state.snackMessage}</span>}
+            action={
+              <IconButton size='small' onClick={() => showSnackbar(false)}>
+                <CloseIcon />
+              </IconButton>
+            }
+          />
+        </Snackbar>
         <AppBar
           position="relative"
           color='default'
@@ -293,6 +304,14 @@ const useStyles = theme => ({
       display: 'none',
     },
   },
+  snackBar: {
+    top: '70px',
+    zOrder: 1000,
+  },
+  snackBarContent: {
+    color: 'inherit',
+    backgroundColor: 'rgb(33 33 33 / 80%)'
+  }
 });
 
 ToolbarButton.propTypes = {

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -10,7 +10,7 @@ import { ShareMenu } from './share-panel';
 
 import { withStyles } from '@material-ui/core/styles';
 
-import { AppBar, Toolbar } from '@material-ui/core';
+import { AppBar, Snackbar, Toolbar } from '@material-ui/core';
 import { Divider } from '@material-ui/core';
 import { Popover, Menu, MenuItem} from "@material-ui/core";
 import { Tooltip } from '@material-ui/core';
@@ -43,6 +43,8 @@ export class Header extends Component {
       anchorEl: null,
       dialogId: null,
       networkLoaded: this.controller.isNetworkLoaded(),
+      snackOpen: false,
+      snackMessage: ""
     };
 
     this.showMobileMenu = this.showMobileMenu.bind(this);
@@ -93,6 +95,10 @@ export class Header extends Component {
       this.showMenu(SHARE_MENU_ID, event.currentTarget);
     };
 
+    const showSnackbar = (open, message ) => {
+      this.setState({ snackOpen: open, snackMessage: message });
+    };
+
     const buttonsDef = [
       {
         title: "Fit Figure to Screen",
@@ -122,6 +128,13 @@ export class Header extends Component {
     
     return (
       <>
+        <Snackbar 
+          style={{zIndex: 100}} 
+          open={this.state.snackOpen} 
+          autoHideDuration={4000} 
+          onClose={() => showSnackbar(false, "")} 
+          message={this.state.snackMessage}
+        />
         <AppBar
           position="relative"
           color='default'
@@ -181,7 +194,11 @@ export class Header extends Component {
               onClose={() => this.handleMenuClose()}
             >
               {menuName === SHARE_MENU_ID && (
-                <ShareMenu controller={controller} />
+                <ShareMenu 
+                  controller={controller} 
+                  onClose={() => this.handleMenuClose()}
+                  showMessage={message => showSnackbar(true, message)}
+                />
               )}
             </Popover>
           )}

--- a/src/client/components/network-editor/legend-button.js
+++ b/src/client/components/network-editor/legend-button.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
-import { saveAs } from 'file-saver';
 import { makeStyles } from '@material-ui/core/styles';
-import { NodeColorLegend, getSVGString } from './legend-svg';
+import { NodeColorLegend } from './legend-svg';
 import { NetworkEditorController } from './controller';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import { Tooltip } from '@material-ui/core';
+
+export const NODE_COLOR_SVG_ID = 'node-color-legend-svg';
 
 const LEGEND_HEIGHT = 220;
 const LEGEND_WIDTH  = 120;
@@ -77,16 +78,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-async function exportLegend(svgID) {
-  const svg = getSVGString(svgID);
-  const blob = new Blob([svg], { type: 'text/plain;charset=utf-8' });
-  saveAs(blob, 'enrichment_map_legend.svg');
-}
-
-
 export function LegendActionButton({ controller }) {
-  const nodeSvgID = 'node-color-legend-svg';
-
   const [ open, toggleOpen ] = useReducer(x => !x, true);
   const [ loading, setLoaded ] = useReducer(() => false, true);
 
@@ -95,12 +87,6 @@ export function LegendActionButton({ controller }) {
       setLoaded();
     controller.bus.on('networkLoaded', setLoaded);
     return () => controller.bus.removeListener('networkLoaded', setLoaded);
-  }, []);
-
-  useEffect(() => {
-    const handleExport = () => exportLegend(nodeSvgID);
-    controller.bus.on('exportLegend', handleExport);
-    return () => controller.bus.removeListener('exportLegend', handleExport);
   }, []);
 
   const classes = useStyles();
@@ -118,7 +104,7 @@ export function LegendActionButton({ controller }) {
       <div className={contentClasses}>
         <h4 className={classes.menuTitle}>Legend</h4>
         <NodeColorLegend 
-          svgID={nodeSvgID}
+          svgID={NODE_COLOR_SVG_ID}
           height={LEGEND_HEIGHT * 0.75}
           magNES={controller.style.magNES} 
         />

--- a/src/client/components/network-editor/legend-svg.js
+++ b/src/client/components/network-editor/legend-svg.js
@@ -9,11 +9,14 @@ export function getSVGString(id) {
   const serializer = new XMLSerializer();
   let xmlString = serializer.serializeToString(svg);
 
+  // remove height attribute
+  xmlString = xmlString.replace(/^<svg height="\d+"/, '<svg ');
+
   // add namespaces
   if(!xmlString.match(/^<svg[^>]+"http:\/\/www\.w3\.org\/1999\/xlink"/)) {
-    // JSX doesn't allow namespace tags, so we have to add it here
     xmlString = xmlString.replace(/^<svg/, '<svg xmlns:xlink="http://www.w3.org/1999/xlink"'); 
   }
+  
   // add xml tag
   xmlString = '<?xml version="1.0" standalone="no"?>\r\n' + xmlString;
 
@@ -25,7 +28,8 @@ export function NodeColorLegend({ height, svgID, magNES }) {
   const nesText = (Math.round((magNES || 1.0) * 100) / 100).toFixed(2);
   return (
     <div>
-      <svg id={svgID} height={height} viewBox="3.003 -2.42 142.521 229.382" xmlns="http://www.w3.org/2000/svg">
+      {/* height attribute must go first so it can be removed on export */}
+      <svg height={height} id={svgID} viewBox="3.003 -2.42 142.521 229.382" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <linearGradient id="gradient-2-0" gradientUnits="userSpaceOnUse" x1="63.525" y1="36.468" x2="63.525" y2="201.138" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlinkHref="#gradient-2"/>
           <linearGradient id="gradient-2">
@@ -53,7 +57,8 @@ NodeColorLegend.propTypes = {
 export function EdgeWidthLegend({ height, svgID }) {
   return (
     <div>
-      <svg id={svgID} height={height} viewBox="0 0 119.499 226.233" xmlns="http://www.w3.org/2000/svg">
+      {/* height attribute must go first so it can be removed on export */}
+      <svg height={height} id={svgID} viewBox="0 0 119.499 226.233" xmlns="http://www.w3.org/2000/svg">
         <text style={{whiteSpace: 'pre', fill: 'rgb(51, 51, 51)', fontFamily: 'Arial, sans-serif', fontSize: '16.2px'}} x="23.162" y="23.857">Similarity</text>
         <rect x="8.696" y="53.344" width="61.708" height="5.688"   style={{fill: 'rgb(216, 216, 216)', stroke: 'rgb(0, 0, 0)'}} transform="matrix(0.707107, -0.707107, 0.707107, 0.707107, -28.772488, 50.495087)"/>
         <rect x="8.696" y="83.033" width="61.708" height="8.853"   style={{fill: 'rgb(216, 216, 216)', stroke: 'rgb(0, 0, 0)'}} transform="matrix(0.707107, -0.707107, 0.707107, 0.707107, -53.56525, 87.485718)"/>

--- a/src/client/components/network-editor/share-panel.js
+++ b/src/client/components/network-editor/share-panel.js
@@ -76,7 +76,7 @@ export function ShareMenu({ controller, onClose = ()=>null, showMessage = ()=>nu
   const handleCopyLink = async () => {
     await handleCopyToClipboard(); 
     onClose();
-    showMessage("Link copied!");
+    showMessage("Link copied to clipboard");
   };
 
   const handleExportImages = async () => {

--- a/src/client/components/network-editor/share-panel.js
+++ b/src/client/components/network-editor/share-panel.js
@@ -42,6 +42,20 @@ async function clearSelectionStyle(controller) {
   return async () => eles.addClass('unselected');
 }
 
+
+function getZipFileName(controller) {
+  const networkName = controller.cy.data('name');
+  if(networkName) {
+    // eslint-disable-next-line no-control-regex
+    const reserved = /[<>:"/\\|?*\u0000-\u001F]/g;
+    if(!reserved.test(networkName)) {
+      return networkName + '.zip';
+    }
+  }
+  return 'enrichment_map_images.zip';
+}
+
+
 async function handleExportImageArchive(controller) {
   const restoreStyle = await clearSelectionStyle(controller);
 
@@ -61,8 +75,9 @@ async function handleExportImageArchive(controller) {
   zip.file('node_color_legend.svg',     blobs[3]);
 
   const archiveBlob = await zip.generateAsync({ type: 'blob' });
-
-  await saveAs(archiveBlob, 'enrichment_map_images.zip');
+  
+  const fileName = getZipFileName(controller);
+  await saveAs(archiveBlob, fileName);
 }
 
 

--- a/src/client/components/network-editor/share-panel.js
+++ b/src/client/components/network-editor/share-panel.js
@@ -7,7 +7,7 @@ import { MenuList, MenuItem, ListItemIcon, ListItemText } from '@material-ui/cor
 import { getSVGString } from './legend-svg';
 import { NODE_COLOR_SVG_ID } from './legend-button';
 import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
-//import LinkIcon from '@material-ui/icons/Link';
+import LinkIcon from '@material-ui/icons/Link';
 
 
 const ImageSize = {
@@ -66,33 +66,45 @@ async function handleExportImageArchive(controller) {
 }
 
 
-// async function handleShareURL() {
-//   const url = window.location.href;
-//   window.navigator.share({
-//     title: "EnrichmentMap Network",
-//     url
-//   });
-// }
+function handleCopyToClipboard() {
+  const url = window.location.href;
+  navigator.clipboard.writeText(url);
+}
 
 
-export function ShareMenu({ controller }) {
-  return <MenuList>
-      {/* <MenuItem onClick={handleShareURL}>
+export function ShareMenu({ controller, onClose = ()=>null, showMessage = ()=>null }) {
+  const handleCopyLink = async () => {
+    await handleCopyToClipboard(); 
+    onClose();
+    showMessage("Link copied!");
+  };
+
+  const handleExportImages = async () => {
+    await handleExportImageArchive(controller); 
+    onClose();
+  };
+
+  return (
+    <MenuList>
+      <MenuItem onClick={handleCopyLink}>
         <ListItemIcon>
           <LinkIcon />
         </ListItemIcon>
-        <ListItemText>Share Link</ListItemText>
-      </MenuItem> */}
-      <MenuItem onClick={() => handleExportImageArchive(controller)}>
+        <ListItemText>Share Link to Network</ListItemText>
+      </MenuItem>
+      <MenuItem onClick={handleExportImages}>
         <ListItemIcon>
           <CloudDownloadIcon />
         </ListItemIcon>
-        <ListItemText>Save Images</ListItemText>
+        <ListItemText>Save Network Images</ListItemText>
       </MenuItem>
-    </MenuList>;
+    </MenuList>
+  );
 }
 ShareMenu.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController).isRequired,
+  onClose: PropTypes.func,
+  showMessage: PropTypes.func
 };
 
 export default ShareMenu;


### PR DESCRIPTION
**General information**

Associated issues: #93, #78

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

This pull request makes the following changes to the share menu...
- Removes the "Send by Email" option and replaces it with a "Share Link to Network" option. This option just copies the URL of the current network to the clipboard.
- Copying the link shows a toast (snackbar) confirming that the link was copied. The toast disappears after 4 seconds, or can be closed manually.
  - Note: I positioned the toast at the top right because the user's attention is already in that area while using the menu. Toasts normally show up at the bottom, but I thought this was better.
- Adds a "Save Network Images" option which allows the user to save a zip file containing images of the network and legend. The network images are png files and come in 3 sizes. The node color legend is a svg.
- Fixes bug #93
  - Note: You may notice in the video that the network selection style briefly flashes as the PNG blobs are generated (at 12s). I'm not sure if there's a way to prevent this.


https://user-images.githubusercontent.com/5350528/230115748-ab3d1f0d-9402-4d08-adf3-5124f5c37ca8.mov


