### PR TITLE
Experimental network improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "cytoscape-dagre": "^2.3.2",
         "cytoscape-edgehandles": "^4.0.1",
         "cytoscape-fcose": "^1.2.3",
-        "cytoscape-popper": "^1.0.7",
+        "cytoscape-popper": "^2.0.0",
         "dotenv": "^6.2.0",
         "dotenv-defaults": "^5.0.0",
         "eventemitter3": "^3.1.2",
@@ -4920,24 +4920,14 @@
       }
     },
     "node_modules/cytoscape-popper": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cytoscape-popper/-/cytoscape-popper-1.0.7.tgz",
-      "integrity": "sha512-b/vfoBL2u9GU+J7eceGT9cZ4hctn/ZzV7PXq4w6fk+45qQuOHtlhpP3WxGKpBXNqENhk7Dk0BwlIYROjYQmidQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-popper/-/cytoscape-popper-2.0.0.tgz",
+      "integrity": "sha512-b7WSOn8qXHWtdIXFNmrgc8qkaOs16tMY0EwtRXlxzvn8X+al6TAFrUwZoYATkYSlotfd/36ZMoeKMEoUck6feA==",
       "dependencies": {
-        "popper.js": "^1.0.0"
+        "@popperjs/core": "^2.0.0"
       },
       "peerDependencies": {
         "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-popper/node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/d3-dispatch": {
@@ -19306,18 +19296,11 @@
       }
     },
     "cytoscape-popper": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cytoscape-popper/-/cytoscape-popper-1.0.7.tgz",
-      "integrity": "sha512-b/vfoBL2u9GU+J7eceGT9cZ4hctn/ZzV7PXq4w6fk+45qQuOHtlhpP3WxGKpBXNqENhk7Dk0BwlIYROjYQmidQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-popper/-/cytoscape-popper-2.0.0.tgz",
+      "integrity": "sha512-b7WSOn8qXHWtdIXFNmrgc8qkaOs16tMY0EwtRXlxzvn8X+al6TAFrUwZoYATkYSlotfd/36ZMoeKMEoUck6feA==",
       "requires": {
-        "popper.js": "^1.0.0"
-      },
-      "dependencies": {
-        "popper.js": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-          "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-        }
+        "@popperjs/core": "^2.0.0"
       }
     },
     "d3-dispatch": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "cytoscape-dagre": "^2.3.2",
     "cytoscape-edgehandles": "^4.0.1",
     "cytoscape-fcose": "^1.2.3",
-    "cytoscape-popper": "^1.0.7",
+    "cytoscape-popper": "^2.0.0",
     "dotenv": "^6.2.0",
     "dotenv-defaults": "^5.0.0",
     "eventemitter3": "^3.1.2",

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -76,9 +76,9 @@ export class NetworkEditorController {
 
     this.layout = this.cy.layout({
       name: 'cose',
-      idealEdgeLength: edge => 50 - 40 * (edge.data('similarity_coefficient')),
-      edgeElasticity: edge => 100 / (edge.data('similarity_coefficient')),
-      nodeRepulsion: node => 10000,
+      idealEdgeLength: edge => 30 - 25 * (edge.data('similarity_coefficient')),
+      edgeElasticity: edge => 10 / (edge.data('similarity_coefficient')),
+      nodeRepulsion: node => 1000,
       // nodeSeparation: 75,
       randomize: true,
       animate: false,
@@ -102,7 +102,9 @@ export class NetworkEditorController {
     const avoidOverlapPadding = 10;
     const cols = Math.floor(layoutWidth / (nodeWidth + avoidOverlapPadding));
 
-    disconnectedNodes.layout({
+    const cmpByNES = (a, b) => b.data('NES') - a.data('NES'); // up then down
+
+    disconnectedNodes.sort(cmpByNES).layout({
       name: 'grid',
       boundingBox: {
         x1: connectedBB.x1,
@@ -122,7 +124,7 @@ export class NetworkEditorController {
 
     // now that we know the zoom level when the graph fits to screen, we can use restrictions
     this.cy.minZoom(this.cy.zoom() * 0.25);
-    this.cy.maxZoom(3);
+    this.cy.maxZoom(2);
   }
 
   /**

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import tippy, { sticky } from 'tippy.js';
 
-import { CONTROL_PANEL_WIDTH } from './defaults';
+import { CONTROL_PANEL_WIDTH, DEFAULT_PADDING } from './defaults';
 import { EventEmitterProxy } from '../../../model/event-emitter-proxy';
 import { NetworkEditorController } from './controller';
 import CollapsiblePanel from './collapsible-panel';
@@ -14,6 +15,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Drawer, Grid, Typography, Tooltip } from '@material-ui/core';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import SearchBar from "material-ui-search-bar";
+import { nodeLabel } from './network-style';
 
 
 const sortOptions = {
@@ -201,21 +203,29 @@ const LeftDrawer = ({ controller, open, isMobile }) => {
     //   })
     // });
 
-    const updateSelectionClass = _.debounce(() => {
+    const updateSelectionClass = () => {
       const allEles = cy.elements();
       const targetEle = allEles.filter(':selected'); // 1 ele
-      const selectedEles = targetEle.isNode() ? targetEle.closedNeighborhood() : targetEle.add(targetEle.connectedNodes());
+      const selectedEles = targetEle.isNode() ? targetEle : targetEle.add(targetEle.connectedNodes());
       const unselectedEles = allEles.subtract(selectedEles);
 
       cy.batch(() => {
         if (allEles.length === unselectedEles.length) {
-          allEles.removeClass('unselected');
+          allEles.removeClass('unselected').removeClass('selected');
         } else {
-          selectedEles.removeClass('unselected');
-          unselectedEles.addClass('unselected');
+          selectedEles.removeClass('unselected').addClass('selected');
+          unselectedEles.addClass('unselected').removeClass('selected');
         }
       });
-    }, 64);
+
+      if (!targetEle.empty()) {
+        cy.animate({
+          fit: { eles: targetEle.component(), padding: DEFAULT_PADDING },
+          easing: 'ease-out',
+          duration: 500
+        });
+      }
+    };
 
     const clearSearch = _.debounce(() => {
       cancelSearch();

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -22,6 +22,13 @@ function getMinMaxValues(cy, attr) {
   };
 }
 
+export const nodeLabel = _.memoize(node => {
+  const text = (node.data('label') ?? node.data('name')).replace(/\_/g, ' ');
+  const percent = text.indexOf('%');
+  
+  return (percent > 0 ? text.substring(0, percent) : text).toLowerCase();
+}, node => node.id());
+
 
 export const createNetworkStyle = (cy) => {
   const { min:minNES, max:maxNES } = getMinMaxValues(cy, 'NES');
@@ -30,12 +37,6 @@ export const createNetworkStyle = (cy) => {
   
   const getBGColor = _.memoize(node => {
     return nesColorScale(node.data('NES')).toString();
-  }, node => node.id());
-
-  const nodeLabel = _.memoize(node => {
-    const text = node.data('label') ?? node.data('name');
-    const percent = text.indexOf('%');
-    return (percent > 0 ? text.substring(0, percent) : text).toLowerCase();
   }, node => node.id());
 
   return {
@@ -48,8 +49,8 @@ export const createNetworkStyle = (cy) => {
         selector: 'node',
         style: {
           'opacity': 1,
-          'border-width': 0,
-          'border-opacity': 0.7,
+          'border-width': 12,
+          'border-opacity': 0,
           'label': nodeLabel,
           'width':  40,
           'height': 40,
@@ -57,7 +58,7 @@ export const createNetworkStyle = (cy) => {
           'text-valign': 'center',
           'text-wrap': 'wrap',
           'text-max-width': 80,
-          'text-outline-width': 1.5,
+          'text-outline-width': 2,
           'text-outline-opacity': 1,
           'color': '#fff'
         }
@@ -72,11 +73,11 @@ export const createNetworkStyle = (cy) => {
       {
         selector: 'edge',
         style: {
-          'line-color' : '#b1d6d8',
+          'line-color' : '#888',
           'line-opacity': 0.6,
           'curve-style': 'haystack',
           'haystack-radius': 0,
-          'width': ele => ele.data('similarity_coefficient') * 20,
+          'width': ele => ele.data('similarity_coefficient') * 30,
         }
       },
       {
@@ -100,40 +101,27 @@ export const createNetworkStyle = (cy) => {
       {
         selector: 'node.unselected',
         style: {
-          'opacity': 0.2
+          
         }
       },
       {
         selector: 'edge.unselected',
         style: {
-          'opacity': 0.1
+          
         }
       },
       {
-        selector: 'node:selected',
+        selector: 'node.selected',
         style: {
-          'border-width': 6,
-          'border-color': '#aadafa',
-          'border-opacity': 0.666
+          'border-width': 12,
+          'border-color': '#5aaae0',
+          'border-opacity': 0.8
         }
       },
       {
-        selector: 'node.eh-preview',
+        selector: 'edge.selected',
         style: {
-          'overlay-opacity': 0.2
-        }
-      },
-      {
-        selector: '.eh-handle',
-        style: {
-          'opacity': 0,
-          'events': 'no'
-        }
-      },
-      {
-        selector: '.eh-ghost-edge.eh-preview-active',
-        style: {
-          'opacity': 0
+          'line-color': '#5aaae0'
         }
       }
     ]

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -10,6 +10,22 @@ import * as Sentry from "@sentry/browser";
 import { BrowserTracing } from "@sentry/tracing";
 import { SENTRY, SENTRY_ENVIRONMENT } from './env';
 
+// See https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-JavaScript
+function xoshiro128ss(a, b, c, d) {
+  return function() {
+      var t = b << 9, r = a * 5; r = (r << 7 | r >>> 25) * 9;
+      c ^= a; d ^= b;
+      b ^= c; a ^= d; c ^= t;
+      d = d << 11 | d >>> 21;
+      return (r >>> 0) / 4294967296;
+  };
+}
+
+const rng = xoshiro128ss(3728386577354669, 4177051891409301, 6293788895719469, 105826358935507);
+
+// monkey patch Math.random() so layouts are deterministic
+Math.random = () => rng();
+
 if( debug.enabled() ){
   debug.init();
 }

--- a/src/styles/cy-tippy.css
+++ b/src/styles/cy-tippy.css
@@ -1,0 +1,28 @@
+.cy-tippy-content {
+  text-align: center;
+  max-width: 200px;
+}
+
+.tippy-popper {
+  transition: none !important;
+}
+
+.tippy-box {
+  background-color: rgb(0 0 0 / 66.6%);
+}
+
+.tippy-box[data-placement^="top"] > .tippy-arrow::before {
+  border-top-color: rgb(0 0 0 / 66.6%);
+}
+
+.tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
+  border-bottom-color: rgb(0 0 0 / 66.6%);
+}
+
+.tippy-box[data-placement^="left"] > .tippy-arrow::before {
+  border-left-color: rgb(0 0 0 / 66.6%);
+}
+
+.tippy-box[data-placement^="right"] > .tippy-arrow::before {
+  border-right-color: rgb(0 0 0 / 66.6%);
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -6,3 +6,4 @@
 @import "./custom-icons.css";
 @import "./components/index.css";
 @import "./scrolling.css";
+@import "./cy-tippy.css";


### PR DESCRIPTION
**General information**

Associated issues:

- #73 
- #80 
- #83 
- #74

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] N/A : Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

This PR has some experimental improvements to the network.  I'm not sure it's ready to be merged in, but I'd like you to try it out.  Maybe you have some ideas to improve it.

I experimented a lot, so the changes aren't very clean.  It might have to be cleaned up in one or more new PRs.

Simple, clear items:

- No more neighbourhood highlight.
- There is a simple, blue highlight.  A blue outline on a selected node.  A blue outline on an edge and its connected nodes for a selected edge.
- Edges stand out more.  Darker and thicker.
- Some node labels have random underscores in them.  Now, they're replaced with spaces.

Re. layout:

- Sort disconnected nodes by NES.  Less random looking.
- Use a fixed seed in the FD layout for deterministic results via monkey patching.  Maybe this should be separated out.  The PRNG is pretty simple, but we might need to discuss this since it's a permanent change if we want permanently consistent layout results.

Re. the issue of not being able to read the network in the default, fit-to-screen zoom level:  This is a difficult one.  I tried several options, like showing tooltips of the node labels on hover or growing the nodes on hover.  Neither of these feels right, and they can be annoying.  So, I concluded that the real issue is that it's too difficult for some users to zoom.  When you zoom in, everything is solved.  You can see all the labels clearly for a group of nodes, and you can just scan with your eyes.  Scanning with your eyes is always faster and easier than any hover effect.  So, I've made zooming in easier:

- Improve style & layout to make better use of space a bit.  It's still hard to read in the fit-to-screen view, but it's a bit better than before.
- Add buttons to control the zoom, by the fit button.  These are useful for users who don't know that they can use the trackpad to zoom (pinch or two-finger scroll, like maps).  Older users.  We have space by the fit button on desktop, and we could hide these new buttons on mobile in future.  On mobile, it's obvious how to zoom in.
- When you click a node, it zooms in for you so you can see it and what's around it.  This makes it easier, because it zooms for you.  Clicking is the most obvious action to get more information, and this makes it so you can see the entire component of the graph that the clicked node belongs to.  Then you can read all of the relevant labels easily.  You can use this a bit like the [Wine and Cheese Map](http://www.wineandcheesemap.com) to navigate between components by clicking a node towards the edge of the screen.
- Add shortcut keys for viewport commands.  Pan with arrows.  Zoom with plus and minus.  Fit with F or spacebar.

Here's a video to summarise:

https://user-images.githubusercontent.com/989043/230173697-8eae3fa7-64b0-4cee-b1c7-a9444597354b.mov

