### PR TITLE
Fixes TypeError when scrolling the gene list

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -296,15 +296,20 @@ const GeneListPanel = ({ controller, genes }) => {
 
     const isGeneTextOverflowing = (id) => {
       const elem = document.getElementById(id);
-      const { overflow } = elem.style;
 
-      if(!overflow || overflow === "visible" )
+      if (elem) {
+        const { overflow } = elem.style;
+
+        if (!overflow || overflow === "visible")
           elem.style.overflow = "hidden";
 
-      const isOverflowing = elem.clientWidth < elem.scrollWidth || elem.clientHeight < elem.scrollHeight;
-      elem.style.overflow = overflow;
+        const isOverflowing = elem.clientWidth < elem.scrollWidth || elem.clientHeight < elem.scrollHeight;
+        elem.style.overflow = overflow;
 
-      return isOverflowing;
+        return isOverflowing;
+      }
+
+      return false;
     };
 
     const loading = genes == null;


### PR DESCRIPTION
**General information**

Associated issues: #106

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

This just adds a verification inside `isGeneTextOverflowing` (_gene-list-panel.js_) to check whether the html element exists.
