### PR TITLE
Force the browser to use the dark mode scrollbar style

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -376,6 +376,7 @@ const GeneListPanel = ({ controller, genes }) => {
       totalCount={totalGenes}
       itemContent={idx => renderGeneRow(idx)}
       overscan={200}
+      style={{ 'background': 'rgb(24, 24, 24)' }} // fixes scrollbar colour on chrome
     />
   );
 };

--- a/src/styles/components/network-editor/index.css
+++ b/src/styles/components/network-editor/index.css
@@ -11,3 +11,10 @@
   bottom: 0;
   top: 50px;
 }
+
+html,
+body {
+  /* fixes scroll bar colour in safari */
+  background: rgb(24 24 24);
+  color-scheme: dark;
+}


### PR DESCRIPTION
**General information**

Associated issues: N/A

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

Makes the scroll bar visible in the sidebar by forcing the browser to go into dark mode.  Otherwise, it's hard to see.


When fixed:

https://user-images.githubusercontent.com/989043/230424705-b6e58aa3-8dba-440a-ab37-ba554fa1cdc7.mov


