### PR TITLE
Better (and fixed) linkout labels

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -175,7 +175,7 @@ const GeneMetadataPanel = ({ symbol, showSymbol }) => {
   const isLoading = query.isLoading;
   let error = query.error;
 
-  let description, ncbiId, ensemblId;
+  let description, ncbiId;
   
   if (!isLoading && !error && data) {
     const entry = data.genes && data.genes.length > 0 ? data.genes[0] : {};
@@ -188,9 +188,6 @@ const GeneMetadataPanel = ({ symbol, showSymbol }) => {
       if (gene) {
         description = gene.description;
         ncbiId = gene['gene_id'];
-        
-        const ensemblGeneIds = gene['ensembl_gene_ids'];
-        ensemblId = ensemblGeneIds && ensemblGeneIds.length > 0 ? ensemblGeneIds[0] : null;
       }
     }
   }
@@ -211,44 +208,38 @@ const GeneMetadataPanel = ({ symbol, showSymbol }) => {
         </span>
       )}
       {!error && (
-        <Grid item xs={12}>
-          <Typography variant="body2" color="textSecondary" className={isLoading ? classes.loadingMsg : null}>
-            {isLoading ? 'Loading...' : description }
-          </Typography>
-        </Grid>
+        <>
+          <Grid item xs={12}>
+            <Typography variant="body2" color="textSecondary" className={isLoading ? classes.loadingMsg : null}>
+              {isLoading ? 'Loading...' : description }
+            </Typography>
+          </Grid>
+          {!isLoading && (
+            <Grid item xs={12}>  
+              <Grid container direction="row" justifyContent="space-between" alignItems='center'>
+                <Grid item>
+                  <Link
+                    href={ncbiId ? `https://www.ncbi.nlm.nih.gov/gene/${ncbiId}` : `https://www.ncbi.nlm.nih.gov/gene?term=(${symbol}%5BGene%20Name%5D)%20AND%209606%5BTaxonomy%20ID%5D`}
+                    className={classes.linkout}
+                    {...linkoutProps}
+                  >
+                    More Info
+                  </Link>
+                </Grid>
+                <Grid item>
+                  <Link
+                    href={`https://genemania.org/search/human/${symbol}`}
+                    className={classes.linkout}
+                    {...linkoutProps}
+                  >
+                    Related Genes
+                  </Link>
+                </Grid>
+              </Grid>
+            </Grid>
+          )}
+        </>
       )}
-      <Grid item xs={12}>  
-        <Grid container direction="row" justifyContent="space-between" alignItems='center'>
-          <Grid item>
-            <Link
-              href={ncbiId ? `https://www.ncbi.nlm.nih.gov/gene/${ncbiId}` : `https://www.ncbi.nlm.nih.gov/gene?term=(${symbol}%5BGene%20Name%5D)%20AND%209606%5BTaxonomy%20ID%5D`}
-              className={classes.linkout}
-              {...linkoutProps}
-            >
-              NCBI Gene
-            </Link>
-          </Grid>
-          <Grid item>
-            <Link
-              href={`https://www.ensembl.org/Homo_sapiens/Gene/Summary?g=${ensemblId ? ensemblId : symbol}`}
-              className={classes.linkout}
-              style={{marginLeft: '2em', marginRight: '2em'}}
-              {...linkoutProps}
-            >
-              Ensembl
-            </Link>
-          </Grid>
-          <Grid item>
-            <Link
-              href={`https://genemania.org/search/human/${symbol}`}
-              className={classes.linkout}
-              {...linkoutProps}
-            >
-              GeneMANIA
-            </Link>
-          </Grid>
-        </Grid>
-      </Grid>
     </Grid>
   );
 };


### PR DESCRIPTION
**General information**

Associated issues: #77

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Hides gene linkouts when:
  a) loading the description;
  b) genes are unrecognized or any other error.
- Removes the **Ensembl** linkout (redundant, the NCBI is more used).
- Renames the **NCBI Gene** link to **More Info**.
- Renames the **GeneMANIA** link to **Related Genes**.

  _Before:_
  <img width="319" alt="EM-linkouts-1" src="https://user-images.githubusercontent.com/989686/231860884-401c249d-6f80-49a1-b398-c9adc8acb9f4.png">

  _After:_
  <img width="320" alt="EM-linkouts-2" src="https://user-images.githubusercontent.com/989686/231860939-bea947ba-bf08-491c-8752-d4655eafaf9d.png">