### PR TITLE
Unselects all elements first when shift-clicking a node/edge

### DIFF
--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -240,7 +240,19 @@ const LeftDrawer = ({ controller, open, isMobile }) => {
     const clearSearch = _.debounce(() => {
       cancelSearch();
     }, 128);
+    
+    cyEmitter.on('click', evt => {
+      // Prevents multi-selection when shift/ctrl/command is pressed...
+      if (evt.originalEvent.ctrlKey || evt.originalEvent.metaKey || evt.originalEvent.shiftKey) {
+        const ele = evt.target;
 
+        if (ele.group && !ele.selected()) {
+          // This is a node/edge and is not selected yet--if already selected, ignore it,
+          // otherwise shift-clicking the same element won't deselect it as usually expected.
+          cy.$(':selected').unselect(); // Unselect everything, so only this clicked element can be selected by Cytoscape.
+        }
+      }
+    });
     cyEmitter.on('select unselect', onCySelectionChanged);
 
     cyEmitter.on('select', () => {


### PR DESCRIPTION
**General information**

Associated issues: #146

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

This prevents multiple selection when clicking a node/edge while pressing one of these keys: SHIFT, CONTROL, COMMAND.
When a modifier+click event is detected, the previous selections is cleared so the currently clicked element is the only one that will be selected by Cytoscape.
Notice that Shift-clicking an already selected element will do nothing different here, so the clicked element can be unselected normally.
