### PR TITLE
Feature/genes drawer improvements

### DIFF
--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -399,7 +399,7 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
               />
               <ToolbarDivider />
               <SearchBar
-                style={{width: 276}}
+                style={{width: 294}}
                 placeholder="Find pathways..."
                 value={searchValue}
                 onChange={search}

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -13,69 +13,30 @@ import { UpDownHBar } from './charts';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
 
 import { Virtuoso } from 'react-virtuoso';
-import { ListItem, ListItemText, Tooltip } from '@material-ui/core';
-import { Grid, Typography, Link } from '@material-ui/core';
+import { List, ListItem, ListItemText, ListItemIcon, ListSubheader } from '@material-ui/core';
+import { Grid, Paper, Typography, Link, Tooltip } from '@material-ui/core';
 import Skeleton from '@material-ui/lab/Skeleton';
 
+import InfoIcon from '@material-ui/icons/Info';
+import SadFaceIcon from '@material-ui/icons/SentimentVeryDissatisfied';
+import KeyboardReturnIcon from '@material-ui/icons/KeyboardReturn';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import { VennUnionIcon } from '../svg-icons';
+
 
 const CHART_WIDTH = 160;
 const CHART_HEIGHT = 16;
 const GENE_RANK_ROUND_DIGITS = 2;
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
-  },
-  listItem: {
-    paddingTop: 4,
-    paddingBottom: 0,
-    backgroundColor: theme.palette.background.paper,
-  },
-  listItemText: {
-    marginTop: 0,
-    marginBottom: 0,
-  },
-  listItemHeader: {
-    height: 24,
-    margin: 0,
-    borderRadius: 4,
-    cursor: 'pointer',
-    '&:hover': {
-      backgroundColor: theme.palette.action.hover,
-    },
-    "&[disabled]": {
-      color: theme.palette.divider,
-      cursor: "default",
-      "&:hover": {
-        textDecoration: "none"
-      }
-    },
-  },
-  bulletIconContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    height: '100%',
-  },
-  bulletIcon: {
-    marginRight: '4px',
-    color: 'inherit',
-    opacity: 0.5
-  },
-  geneContainer: {
-    width: '40%',
-  },
+
+const useGeneMetadataPanelStyles = makeStyles((theme) => ({
   geneName: {
     color: 'inherit', 
     whiteSpace:'nowrap', 
     overflow:'hidden', 
     textOverflow:'ellipsis'
-  },
-  chartContainer: {
-    width: CHART_WIDTH,
-    padding: '0 8px',
   },
   geneMetadata: {
     fontSize: '1.0em',
@@ -85,22 +46,6 @@ const useStyles = makeStyles((theme) => ({
     borderWidth: 1,
     borderColor: theme.palette.divider,
     borderStyle: 'hidden hidden hidden solid',
-  },
-  geneRankCollapsed: {
-    fontSize: '0.75rem',
-    fontFamily: 'monospace',
-    color: theme.palette.text.disabled,
-    marginTop: '-0.25em',
-    paddingRight: '0.75em',
-  },
-  geneRankExpanded: {
-    fontSize: '0.75rem',
-    fontFamily: 'monospace',
-    textAlign: 'right',
-    color: theme.palette.text.disabled,
-    marginTop: '-0.25em',
-    marginBottom: '0.75em',
-    paddingRight: '0.05em',
   },
   linkout: {
     fontSize: '0.75rem',
@@ -131,7 +76,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const GeneMetadataPanel = ({ controller, symbol, showSymbol }) => {
-  const classes = useStyles();
+  const classes = useGeneMetadataPanelStyles();
 
   const queryGeneData = useQuery(
     ['gene-metadata', symbol],
@@ -230,11 +175,174 @@ const GeneMetadataPanel = ({ controller, symbol, showSymbol }) => {
     </Grid>
   );
 };
+GeneMetadataPanel.propTypes = {
+  controller: PropTypes.instanceOf(NetworkEditorController).isRequired,
+  symbol: PropTypes.string.isRequired,
+  showSymbol: PropTypes.func
+};
 
-const GeneListPanel = ({ controller, genes, sort, isMobile }) => {
+
+const useNoResultsBoxStyles = makeStyles((theme) => ({
+  mainIcon: {
+    fontSize: '4em',
+    opacity: 0.4,
+  },
+  noResultsBox: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    width: '100%',
+    height: '100%',
+    padding: theme.spacing(2),
+    textAlign: 'center',
+  },
+  noResultsInfoBox: {
+    width: '100%',
+    maxWidth: 360,
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(2),
+    backgroundColor: theme.palette.background.default,
+    borderRadius: 16,
+  },
+  noResultsLine: {
+    marginTop: theme.spacing(1),
+  },
+  noResultsSubheader: {
+    lineHeight: '1.25em',
+    textAlign: 'left',
+    marginBottom: theme.spacing(2),
+    color: theme.palette.text.disabled,
+  },
+  noResultsItem: {
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  noResultsItemIcon: {
+    minWidth: 'unset',
+  },
+  noResultsItemIconIcon: {
+    transform: 'scaleX(-1)',
+    fontSize: '1em',
+    marginRight: theme.spacing(1),
+    color: theme.palette.text.disabled,
+    opacity: 0.5,
+  },
+  noResultsItemText: {
+    margin: 0,
+    color: theme.palette.text.disabled,
+  },
+}));
+
+const NoResultsBox = ({ isSearch }) => {
+  const classes = useNoResultsBoxStyles();
+
+  return (
+    <Paper className={classes.noResultsBox}>
+      <Typography component="p" color="textSecondary" className={classes.noResultsLine}>
+        { isSearch ? <SadFaceIcon className={classes.mainIcon} /> : <InfoIcon className={classes.mainIcon} /> }
+      </Typography>
+      <Typography
+        component="p"
+        variant="subtitle1"
+        color="textSecondary"
+        className={classes.noResultsLine}
+        style={{fontSize: '1.5em', opacity: 0.4}}
+      >
+        { isSearch ? 'No genes found' : 'No common genes for the selected pathways' }
+      </Typography>
+    {!isSearch && (
+      <Paper variant="outlined" className={classes.noResultsInfoBox}>
+        <List
+          dense
+          subheader={
+            <ListSubheader className={classes.noResultsSubheader}>
+              Try one of the following:
+            </ListSubheader>
+          }
+        >
+          <ListItem className={classes.noResultsItem}>
+            <ListItemIcon className={classes.noResultsItemIcon}>
+              <KeyboardReturnIcon className={classes.noResultsItemIconIcon} />
+            </ListItemIcon>
+            <ListItemText
+              className={classes.noResultsItemText}
+              primary={
+                <Grid container>
+                  <span>select the&nbsp;&nbsp;&nbsp;</span>
+                  <VennUnionIcon style={{fontSize: '1.5em', color: theme.palette.text.secondary}} />
+                  <span style={{color: theme.palette.text.secondary}}>&nbsp;Union</span>
+                  <span>&nbsp;&nbsp;&nbsp;option</span>
+                </Grid>
+              }
+            />
+          </ListItem>
+          <ListItem className={classes.noResultsItem}>
+            <ListItemIcon className={classes.noResultsItemIcon}>
+              <KeyboardReturnIcon className={classes.noResultsItemIconIcon} />
+            </ListItemIcon>
+            <ListItemText className={classes.noResultsItemText} primary="select fewer pathways" />
+          </ListItem>
+        </List>
+      </Paper>
+    )}
+    </Paper>
+  );
+};
+NoResultsBox.propTypes = {
+  isSearch: PropTypes.bool,
+};
+
+
+const useGeneListPanelStyles = makeStyles((theme) => ({
+  listItem: {
+    paddingTop: 4,
+    paddingBottom: 0,
+    backgroundColor: theme.palette.background.paper,
+  },
+  listItemText: {
+    marginTop: 0,
+    marginBottom: 0,
+  },
+  listItemHeader: {
+    height: 24,
+    margin: 0,
+    borderRadius: 4,
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+    "&[disabled]": {
+      color: theme.palette.divider,
+      cursor: "default",
+      "&:hover": {
+        textDecoration: "none"
+      }
+    },
+  },
+  bulletIconContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    height: '100%',
+  },
+  bulletIcon: {
+    marginRight: '4px',
+    color: 'inherit',
+    opacity: 0.5
+  },
+  geneContainer: {
+    width: '40%',
+  },
+  chartContainer: {
+    width: CHART_WIDTH,
+    padding: '0 8px',
+  },
+}));
+
+const GeneListPanel = ({ controller, genes, sort, isSearch, isIntersection, isMobile }) => {
   const [selectedGene, setSelectedGene] = useState(null);
   const [resetScroll, setResetScroll] = useState(true);
-  const classes = useStyles();
+  const classes = useGeneListPanelStyles();
   const virtuoso = useRef();
 
   const cy = controller.cy;
@@ -245,13 +353,17 @@ const GeneListPanel = ({ controller, genes, sort, isMobile }) => {
   }, [genes, sort]);
 
   useEffect(() => {
-    if (resetScroll && virtuoso.current) {
+    if (resetScroll && virtuoso && virtuoso.current) {
       virtuoso.current.scrollToIndex({
         index: 0,
         behavior: 'auto',
       });
     }
   });
+
+  if ((isSearch || isIntersection) && genes && genes.length === 0) {
+    return <NoResultsBox isSearch={isSearch} isIntersection={isIntersection} />;
+  }
 
   const toggleGeneDetails = async (symbol) => {
     setResetScroll(false);
@@ -408,16 +520,12 @@ const GeneListPanel = ({ controller, genes, sort, isMobile }) => {
     />
   );
 };
-
-GeneMetadataPanel.propTypes = {
-  controller: PropTypes.instanceOf(NetworkEditorController).isRequired,
-  symbol: PropTypes.string.isRequired,
-  showSymbol: PropTypes.func
-};
 GeneListPanel.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController).isRequired,
   genes: PropTypes.array,
   sort: PropTypes.string,
+  isSearch: PropTypes.bool,
+  isIntersection: PropTypes.bool,
   isMobile: PropTypes.bool,
 };
 

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
   listItem: {
     paddingTop: 4,
     paddingBottom: 0,
+    backgroundColor: theme.palette.background.paper,
   },
   listItemText: {
     marginTop: 0,
@@ -118,25 +119,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-start',
-  },
-  pathwayNameUl: {
-    listStyleType: 'none',
-    margin: 0,
-    padding: 0,
-    paddingLeft: '1em',
-    borderLeft: '1px solid #3A393A'
-  },
-  pathwayNameLi: {
-    whiteSpace:'nowrap', 
-    overflow:'hidden', 
-    textOverflow:'ellipsis',
-    fontSize: '0.75rem',
-    color: 'rgba(255, 255, 255, 0.7)'
-  },
-  pathwayNameTitle: {
-    marginTop: '0.333em',
-    color: 'rgba(255, 255, 255, 0.7)',
-    fontSize: '0.75rem'
   },
   '@keyframes blinker': {
     from: {

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -18,7 +18,6 @@ import { Tooltip } from '@material-ui/core';
 import { IconButton, Box } from '@material-ui/core';
 
 import { AppLogoIcon } from '../svg-icons';
-import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import FitScreenIcon from '@material-ui/icons/SettingsOverscan';
 import ReplyIcon from '@material-ui/icons/Reply';
@@ -283,16 +282,18 @@ export function Header({ controller, classes, showControlPanel, isMobile, onShow
       className={clsx(classes.appBar, { [classes.appBarShift]: shiftAppBar })}
     >
       <Toolbar variant="dense" className={classes.toolbar}>
+      {!showControlPanel && (
         <ToolbarButton
           title="Genes"
-          icon={showControlPanel ? <KeyboardArrowLeftIcon fontSize="large" /> : <KeyboardArrowRightIcon fontSize="large" />}
+          icon={<KeyboardArrowRightIcon fontSize="large" />}
           edge="start"
           onClick={() => onShowControlPanel(!showControlPanel)}
         />
+      )}
         <Box component="div" sx={{ display: { xs: 'none', sm: 'inline-block' }}}>
           <Tooltip arrow placement="bottom" title="Home">
             <IconButton 
-              aria-label='close' 
+              aria-label='home' 
               onClick={() => location.href = '/'}
             >
               <AppLogoIcon style={{ fontSize: 26 }} />

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -161,6 +161,10 @@ export function NetworkEditor({ id }) {
     }
   };
 
+  const onHideControlPanel = () => {
+    setShowControlPanel(false);
+  };
+
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
@@ -178,6 +182,7 @@ export function NetworkEditor({ id }) {
             showControlPanel={showControlPanel}
             isMobile={mobile}
             onContentClick={onContentClick}
+            onHideControlPanel={onHideControlPanel}
           />
         </div>
       </ThemeProvider>

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -182,17 +182,18 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
 
   const debouncedSelectionHandler = _.debounce(async () => {
     const eles = cy.nodes(':childless:selected');
+    const intersection = setOperationRef.current === 'intersection';
 
     if (eles.length > 0) {
       setGenes(null);
       if (eles.length === 1) {
         setSort(eles[0].data('NES') < 0 ? 'up' : 'down');
       }
-      const genes = await fetchGeneListFromElements(eles, setOperationRef.current === 'intersection');
+      const genes = await fetchGeneListFromElements(eles, intersection);
       setGenes(sortGenes(genes, sortRef.current));
     } else if (searchValueRef.current == null || searchValueRef.current.trim() === '') {
       setGenes(null);
-      const genes = await fetchAllRankedGenes();
+      const genes = await fetchAllRankedGenes(intersection);
       setGenes(sortGenes(genes, sortRef.current));
     }
   }, 250);
@@ -388,7 +389,14 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
         </div>
         <div className={classes.drawerContent}>
         {networkLoaded && geneListIndexed && (
-          <GeneListPanel controller={controller} genes={genes} sort={sort} isMobile={isMobile} />
+          <GeneListPanel
+            controller={controller}
+            genes={genes}
+            sort={sort}
+            isSearch={searchResult && searchResult !== ''}
+            isIntersection={setOperation === 'intersection'}
+            isMobile={isMobile}
+          />
         )}
       </div>
     </Drawer>

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -14,7 +14,7 @@ import { FormControl, IconButton, Select, MenuItem, ListItemIcon, ListItemText }
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import SearchBar from './search-bar';
 
-import CloseIcon from '@material-ui/icons/Close';
+import KeyboardArrowLeftIcon from '@material-ui/icons/KeyboardArrowLeft';
 import { VennIntersectionIcon, VennUnionIcon } from '../svg-icons';
 
 
@@ -282,7 +282,6 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
   };
 
   const totalGenes = genes != null ? genes.length : -1;
-  const setOperationsVisible = searchValue == null || searchValue === '';
   const setOperationsDisabled = searchValue != null && searchValue !== '';
   const sortDisabled = totalGenes <= 0;
   
@@ -314,11 +313,9 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
             )}
             </Typography>
             <div className={classes.grow} />
-          {isMobile && (
             <IconButton className={classes.hideButton} onClick={onHide}>
-              <CloseIcon />
+              <KeyboardArrowLeftIcon fontSize="large" />
             </IconButton>
-          )}
           </Toolbar>
           <Grid container direction="column" spacing={2} className={classes.drawerControls}>
             <Grid item style={{padding: 0}}>
@@ -339,7 +336,6 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
             <Grid item>
               <Grid container direction="row" justifyContent="space-between" alignItems="center">
                 <Grid item>
-                {/* {setOperationsVisible && ( */}
                   <FormControl variant="filled" size="small" disabled={setOperationsDisabled}>
                     <Select
                       variant="outlined"
@@ -364,7 +360,6 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
                     ))}
                     </Select>
                   </FormControl>
-                {/* )} */}
                 </Grid>
                 <Grid item>
                   <ToggleButtonGroup

--- a/src/client/components/network-editor/main.js
+++ b/src/client/components/network-editor/main.js
@@ -68,7 +68,7 @@ const NetworkBackground = ({ controller }) => {
   );
 };
 
-const Main = ({ controller, showControlPanel, isMobile, onContentClick }) => {
+const Main = ({ controller, showControlPanel, isMobile, onContentClick, onHideControlPanel }) => {
   const [bottomDrawerOpen, setBottomDrawerOpen] = useState(false);
   const classes = useStyles();
 
@@ -84,7 +84,7 @@ const Main = ({ controller, showControlPanel, isMobile, onContentClick }) => {
       className="network-editor-content"
       onClick={onContentClick}
     >
-      <LeftDrawer open={showControlPanel} isMobile={isMobile} controller={controller} />
+      <LeftDrawer open={showControlPanel} isMobile={isMobile} controller={controller} onHide={onHideControlPanel} />
       <div className={classes.background}>
         <div className={clsx(classes.cy, { [classes.cyShiftX]: shiftXCy, [classes.cyShiftY]: shiftYCy })}>
           <div id="cy" className={classes.cy} style={{ zIndex: 1, width: '100%', height: '100%' }} />
@@ -109,6 +109,7 @@ Main.propTypes = {
   showControlPanel: PropTypes.bool.isRequired,
   isMobile: PropTypes.bool.isRequired,
   onContentClick: PropTypes.func.isRequired,
+  onHideControlPanel: PropTypes.func.isRequired,
 };
 
 export default Main;

--- a/src/client/components/network-editor/pathway-table.js
+++ b/src/client/components/network-editor/pathway-table.js
@@ -366,7 +366,7 @@ const PathwayTable = (
           className={classes.noResultsLine}
           style={{fontSize: '1.5em', opacity: 0.4}}
         >
-           No results found
+           No pathways found
         </Typography>
         <Paper variant="outlined" className={classes.noResultsInfoBox}>
           <List

--- a/src/client/components/network-editor/search-bar.js
+++ b/src/client/components/network-editor/search-bar.js
@@ -11,8 +11,6 @@ import CloseIcon from '@material-ui/icons/Close';
 const useStyles = makeStyles((theme) => ({
   search: {
     position: 'relative',
-    marginLeft: 0,
-    marginRight: 0,
     borderWidth: '1px',
     borderStyle: 'solid',
     borderRadius: theme.spacing(4),

--- a/src/client/theme.js
+++ b/src/client/theme.js
@@ -10,9 +10,9 @@ const theme = createTheme({
       main: '#B4B4B4',
     },
     background: {
-      default: '#181818',
-      paper: '#222222',
-      focus: '#000000',
+      default: '#121212',
+      paper: '#1E1E1E',
+      focus: '#080808',
     },
     error: {
       main: '#db4f4f',


### PR DESCRIPTION
Associated issues: #191, #193

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Adds a "Hide" button to the _Genes_ drawer.
- "Union/Intersection" selection and "Sort" buttons moved to another line.

  <img width="25%" alt="hide-drawer-button" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989686/52da2644-6fd5-4794-80f1-50e265879e42">

- Adds a "no results" message box for **a)** gene search and **b)** no common genes.

  <img width="25%" alt="no-genes" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989686/add68b10-7242-4106-a596-92fb09f80998">
  <img width="25%" alt="no-intersection" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989686/a18b7eff-4e71-47a6-bbd5-6fa2c628dc97">

- Fixes issue where gene list shows the 'union' of genes when all pathways are deselected even though the option is set to 'intersection'.
- Several minor UI tweaks.