### PR TITLE
Feature/bubbleset optimize

### DIFF
--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -349,12 +349,12 @@ export class NetworkEditorController {
 
     let edges = nodes.internalEdges();
     if(large) {
-      edges = edges.shuffle().slice(0, 400); // Take a random sample of edges
+      edges = edges.shuffle().slice(0, 300); // Take a random sample of edges
     }
 
     const c = clusterColor(parent); // Average NES needs to be set on the parent first
     const rgb = `rgb(${c.r}, ${c.g}, ${c.b}, 0.2)`;
-    const throttle = large ? 1000 : 50; // makes animation smoother
+    const throttle = large ? 250 : 50; 
 
     const bubblePath = this.bubbleSets.addPath(nodes, edges, null, {
       virtualEdges: false,

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -8,6 +8,10 @@ import { monkeyPatchMathRandom, restoreMathRandom } from '../../rng';
 import { SearchController } from './search-contoller';
 import { UndoHandler } from './undo-stack';
 
+// Clusters that have this many nodes get optimized.
+// Note we are using number of nodes as a proxy for number of edges, assuming large clusters are mostly complete.
+const LARGE_CLUSTER_SIZE = 33; // approx 500 edges in a complete graph
+
 export const CoSELayoutOptions = {
   name: 'cose',
   idealEdgeLength: edge => 30 - 25 * (edge.data('similarity_coefficient')),
@@ -239,13 +243,13 @@ export class NetworkEditorController {
     const spacingFactor = collapsed ? (1.0 / shrinkFactor) : shrinkFactor;
 
     const nodes = parent.children();
-    const edges = this.internalEdges(nodes);
+    const edges = nodes.internalEdges();
 
-    const layout = parent.children().layout({
+    const layout = nodes.layout({
       name: 'preset',
       positions: n => n.position(),
       fit: false,
-      animate,
+      animate: animate && nodes.size() < LARGE_CLUSTER_SIZE,
       spacingFactor
     });
     
@@ -295,11 +299,6 @@ export class NetworkEditorController {
     }
   }
 
-
-  internalEdges(cluster) {
-    return cluster.connectedEdges().filter(e => cluster.contains(e.source()) && cluster.contains(e.target()));
-  }
-
   /**
    * positions is an array of objects of the form...
    * [ { id: "node-id", x:1.2, y:3.4 }, ...]
@@ -346,19 +345,22 @@ export class NetworkEditorController {
       return;
 
     const nodes = parent.children();
-    const edges = this.internalEdges(nodes);
-    const c     = clusterColor(parent); // Average NES needs to be set on the parent first
-    const rgb   = `rgb(${c.r}, ${c.g}, ${c.b}, 0.2)`;
+    const large = nodes.size() >= LARGE_CLUSTER_SIZE;
+
+    let edges = nodes.internalEdges();
+    if(large) {
+      edges = edges.shuffle().slice(0, 400); // Take a random sample of edges
+    }
+
+    const c = clusterColor(parent); // Average NES needs to be set on the parent first
+    const rgb = `rgb(${c.r}, ${c.g}, ${c.b}, 0.2)`;
+    const throttle = large ? 1000 : 50; // makes animation smoother
 
     const bubblePath = this.bubbleSets.addPath(nodes, edges, null, {
       virtualEdges: false,
-      interactive: true,
-      throttle: 10, // makes animation smoother
-      style: {
-        'fill': rgb,
-        'stroke': rgb,
-        'stroke-width': 1,
-      }
+      interactive: false,
+      throttle,
+      style: { 'fill': rgb, 'stroke': rgb, 'stroke-width': 1 }
     });
 
     // Save the bubblePath object in the parent node

--- a/src/client/cy-extensions.js
+++ b/src/client/cy-extensions.js
@@ -21,7 +21,6 @@ export const registerCytoscapeExtensions = () => {
   // Collection extensions
   Cytoscape.use(internalEdges);
   Cytoscape.use(shuffle);
-  Cytoscape.use(centroid);
 };
 
 
@@ -53,23 +52,4 @@ function shuffle(cy) {
     return eles.cy().collection(arr);
   };
   cy('collection', 'shuffle', shuffleImpl);
-}
-
-
-function centroid(cy) {
-  const centroidImpl = function() {
-    const eles = this;
-    let xs = 0, ys = 0, total = 0;
-    eles.nodes().forEach(node => {
-      const pos = node.position();
-      xs += pos.x;
-      ys += pos.y;
-      total++;
-    });
-    return {
-      x: xs/total, 
-      y: ys/total 
-    };
-  };
-  cy('collection', 'centroid', centroidImpl);
 }

--- a/src/client/cy-extensions.js
+++ b/src/client/cy-extensions.js
@@ -15,8 +15,61 @@ export const registerCytoscapeExtensions = () => {
   Cytoscape.use(fcose);
   Cytoscape.use(cola);
   Cytoscape.use(coseBilkent);
-
   Cytoscape.use(BubbleSets);
-
   Cytoscape.use(popper);
+
+  // Collection extensions
+  Cytoscape.use(internalEdges);
+  Cytoscape.use(shuffle);
+  Cytoscape.use(centroid);
 };
+
+
+
+function internalEdges(cy) {
+  const internalEdgesImpl = function(node) {
+    const eles = this;
+    const cluster = eles.nodes();
+    const nodes = node ? node : cluster;
+    return nodes.connectedEdges().filter(e => cluster.contains(e.source()) && cluster.contains(e.target()));
+  };
+  cy('collection', 'internalEdges', internalEdgesImpl);
+}
+
+
+function shuffle(cy) {
+  const shuffleArray = arr => {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const temp = arr[i];
+      arr[i] = arr[j];
+      arr[j] = temp;
+    }
+  };
+  const shuffleImpl = function() {
+    const eles = this;
+    const arr = eles.toArray();
+    shuffleArray(arr);
+    return eles.cy().collection(arr);
+  };
+  cy('collection', 'shuffle', shuffleImpl);
+}
+
+
+function centroid(cy) {
+  const centroidImpl = function() {
+    const eles = this;
+    let xs = 0, ys = 0, total = 0;
+    eles.nodes().forEach(node => {
+      const pos = node.position();
+      xs += pos.x;
+      ys += pos.y;
+      total++;
+    });
+    return {
+      x: xs/total, 
+      y: ys/total 
+    };
+  };
+  cy('collection', 'centroid', centroidImpl);
+}


### PR DESCRIPTION
**General information**

Associated issues: #192

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Addresses performance issues of large clusters.
- The performance problem is caused by the bubbleset around the cluster, it can't handle the amount of edges.
- The solution does the following.
  - Defines a "large" cluster as having 33 or more nodes. A complete graph of 33 nodes has about 500 edges, and thats where I start seeing performance issues. This value could be changed as needed.
  - For large clusters sets the throttle rate to reduce how often the bubbleset is re-rendered.
  - For large clusters takes a random sample of edges and uses those when creating the bubbleset.
- This pull request also adds extension methods on Collection in the cy-extensions.js file.
