### PR TITLE
NES Legend with multiple tick marks

### DIFF
--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -144,7 +144,7 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
   const [ open, setOpen ] = useState(false);
   const [ disabled, setDisabled ] = useState(true);
   const [ searchValue, setSearchValue ] = useState('');
-  const [ selectedNES, setSelectedNES ] = useState();
+  const [ selectedNESValues, setSelectedNESValues ] = useState([]);
   const [ data, setData ] = useState([]);
   const [ searchTerms, setSearchTerms ] = useState();
   const [ selectedRows, setSelectedRows ] = useState([]);
@@ -187,14 +187,12 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
     // Selected rows
     const selRows = getSelectedRows(sortFnRef.current);
     setSelectedRows(selRows);
-    // NES (only if there's only one selected pathway)
-    if (selRows.length === 1) {
-      const nes = selRows[0].nes;
-      if (nes !== selectedNES) {
-        setSelectedNES(nes);
-      }
+    // NES values
+    if (selRows.length > 0) {
+      const nesValues = selRows.map(r => r.nes);
+      setSelectedNESValues(nesValues);
     } else {
-      setSelectedNES(null);
+      setSelectedNESValues([]);
     }
     if (currentRowRef.current) {
       if (selRows.findIndex(r => r.id === currentRowRef.current.id) === -1) {
@@ -419,7 +417,7 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
             <Grid container direction="column" spacing={0} style={{minWidth: 40, maxWidth: 300, width: '100%', marginTop: 16}}>
               <Grid item>
                 <UpDownLegend
-                  value={selectedNES}
+                  values={selectedNESValues}
                   minValue={-magNES}
                   maxValue={magNES}
                   downColor={REG_COLOR_RANGE.downMax}

--- a/src/client/components/network-editor/charts.js
+++ b/src/client/components/network-editor/charts.js
@@ -101,12 +101,70 @@ UpDownHBar.propTypes = {
 
 // ==[ Up-Down Gradient LEGEND ]=============================================================================================================
 
-export const UpDownLegend = ({ value, minValue, maxValue, downColor, zeroColor, upColor, height, tooltip, style }) => {
-  let left = 0;
-  if (value) {
-    left = (value - minValue) / (maxValue - minValue);
-    left *= 100;
+const _mainValue = (values) => {
+  if (values && values.length > 0) {
+    if (values.length === 1) {
+      return values[0];
+    } else {
+      let val = 0;
+      values.forEach(v => val += v);
+      val /= values.length;
+
+      return val;
+    }
   }
+
+  return undefined;
+};
+
+export const UpDownLegend = ({ values = [], minValue, maxValue, downColor, zeroColor, upColor, height, tooltip, style }) => {
+  const mainVal = _mainValue(values);
+  const total  = values.length;
+
+  const Mark = ({ val, isMain, isAvg }) => {
+    let left = 0;
+    if (val) {
+      left = (val - minValue) / (maxValue - minValue);
+      left *= 100;
+    }
+
+    return (
+      <>
+      {isMain && (
+        <Tooltip title={tooltip ? tooltip : ''}>
+          <Typography
+            color="textPrimary"
+            style={{
+              position: 'absolute',
+              left: `${left}%`,
+              transform: 'translate(-50%, -100%)',
+              fontSize: '0.85em',
+            }}
+          >
+            { numToText(val) + (isAvg ? ' (avg.)' : '') }
+          </Typography>
+        </Tooltip>
+      )}
+        <div
+          style={{
+            position: 'absolute',
+            top: isMain ? height / 2 - 2 : '50%',
+            left: `${left}%`,
+            width: isMain ? 3 : 1,
+            height: isMain ? height + 4 : height,
+            marginTop: -height / 2,
+            backgroundColor: isMain ? theme.palette.text.primary : 'rgba(0,0,0,0.25)',
+            border: isMain ? `1px solid ${theme.palette.background.default}` : 'none',
+          }}
+        />
+      </>
+    );
+  };
+  Mark.propTypes = {
+    val: PropTypes.number.isRequired,
+    isMain: PropTypes.bool,
+    isAvg: PropTypes.bool,
+  };
 
   return (
     <div style={style}>
@@ -116,44 +174,20 @@ export const UpDownLegend = ({ value, minValue, maxValue, downColor, zeroColor, 
           width: '100%',
           height: height,
           background: `linear-gradient(to right, ${downColor} 0%, ${zeroColor} 50%, ${upColor} 100%)`,
-          border: `2px solid ${theme.palette.divider}`,
         }}
       >
-      {value && (
-        <>
-          <Tooltip title={tooltip ? tooltip : ''}>
-            <Typography
-              color="textPrimary"
-              style={{
-                position: 'absolute',
-                left: `${left}%`,
-                transform: 'translate(-50%, -100%)',
-                fontSize: '0.85em',
-              }}
-            >
-              { numToText(value) }
-            </Typography>
-          </Tooltip>
-          <div
-            style={{
-              position: 'absolute',
-              top: '50%',
-              left: `${left}%`,
-              width: 3,
-              height: height,
-              marginTop: -height / 2,
-              backgroundColor: theme.palette.text.primary,
-              border: `1px solid ${theme.palette.background.default}`,
-            }}
-          />
-        </>
+      {total > 1 && values.map((val, idx) => (
+        <Mark key={idx} val={val} />
+      ))}
+      {mainVal && (
+        <Mark val={mainVal} isMain={true} isAvg={total > 1} />
       )}
       </div>
     </div>
   );
 };
 UpDownLegend.propTypes = {
-  value: PropTypes.number,
+  values: PropTypes.arrayOf(PropTypes.number),
   minValue: PropTypes.number.isRequired,
   maxValue: PropTypes.number.isRequired,
   downColor: PropTypes.string.isRequired,

--- a/src/client/components/network-editor/charts.js
+++ b/src/client/components/network-editor/charts.js
@@ -133,12 +133,15 @@ export const UpDownLegend = ({ values = [], minValue, maxValue, downColor, zeroC
       {isMain && (
         <Tooltip title={tooltip ? tooltip : ''}>
           <Typography
+            component="span"
             color="textPrimary"
             style={{
               position: 'absolute',
               left: `${left}%`,
               transform: 'translate(-50%, -100%)',
               fontSize: '0.85em',
+              width: 100,
+              textAlign: 'center',
             }}
           >
             { numToText(val) + (isAvg ? ' (avg.)' : '') }


### PR DESCRIPTION
**General information**

Associated issues: #200

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

When multiple nodes are selected, the NES legend now shows:
- one thin tick mark per selected node
- one "main" (thicker) tick mark for the average value.
<img width="376" alt="legend-multiple" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989686/291ee277-ad63-43b9-9b08-a8ed10051cbe">

If only one node is selected, nothing changed--still shows the "main" tick mark with the NES value label.
<img width="378" alt="legend-one" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989686/a4a67c77-e230-43d0-80d0-7f7d828fc2ad">

