### PR TITLE
Feature/responsive pathway panel

### DIFF
--- a/src/client/components/defaults.js
+++ b/src/client/components/defaults.js
@@ -1,6 +1,22 @@
 export const DEFAULT_PADDING = 10;
-export const CONTROL_PANEL_WIDTH = 320;
+export const HEADER_HEIGHT = 50;
+export const LEFT_DRAWER_WIDTH = 320;
+/** The height of the bottom drawer when collapsed */
 export const BOTTOM_DRAWER_HEIGHT = 48;
-export const PATHWAY_TABLE_HEIGHT = 400;
 
 export const linkoutProps = { target: "_blank",  rel: "noreferrer", underline: "hover" };
+
+
+export function bottomDrawerHeight() {
+  // The preferred height is 1/3 of the height of the content area (excludes the header)
+  const h = Math.round((window.innerHeight - HEADER_HEIGHT) * 0.33);
+  const min = 4 * BOTTOM_DRAWER_HEIGHT; // ...but set a minimum height
+
+  return Math.max(min, h);
+}
+
+export function pathwayTableHeight() {
+  const dh = bottomDrawerHeight();
+  
+  return dh - BOTTOM_DRAWER_HEIGHT;
+}

--- a/src/client/components/defaults.js
+++ b/src/client/components/defaults.js
@@ -3,6 +3,8 @@ export const HEADER_HEIGHT = 50;
 export const LEFT_DRAWER_WIDTH = 320;
 /** The height of the bottom drawer when collapsed */
 export const BOTTOM_DRAWER_HEIGHT = 48;
+/** Whether the bottom drawer must be open (expanded) by default */
+export const BOTTOM_DRAWER_OPEN = false; 
 
 export const linkoutProps = { target: "_blank",  rel: "noreferrer", underline: "hover" };
 
@@ -16,7 +18,7 @@ export function bottomDrawerHeight() {
 }
 
 export function pathwayTableHeight() {
-  const dh = bottomDrawerHeight();
+  const dh = bottomDrawerHeight() - BOTTOM_DRAWER_HEIGHT;
   
-  return dh - BOTTOM_DRAWER_HEIGHT;
+  return dh;
 }

--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import clsx from 'clsx';
 
-import { CONTROL_PANEL_WIDTH, BOTTOM_DRAWER_HEIGHT } from '../defaults';
+import { LEFT_DRAWER_WIDTH, BOTTOM_DRAWER_HEIGHT } from '../defaults';
 import { EventEmitterProxy } from '../../../model/event-emitter-proxy';
 import { NetworkEditorController } from './controller';
 import { pathwayDBLinkOut } from './links';
@@ -15,7 +15,7 @@ import { UpDownLegend, numToText } from './charts';
 import { makeStyles } from '@material-ui/core/styles';
 
 import Collapse from '@material-ui/core/Collapse';
-import { AppBar, Toolbar, Divider, Grid} from '@material-ui/core';
+import { AppBar, Toolbar, Divider, Grid } from '@material-ui/core';
 import { Drawer, Tooltip, Typography } from '@material-ui/core';
 import { Button, IconButton } from '@material-ui/core';
 
@@ -70,8 +70,8 @@ const useBottomDrawerStyles = makeStyles((theme) => ({
     }),
   },
   appBarShift: {
-    width: `calc(100% - ${CONTROL_PANEL_WIDTH}px)`,
-    marginLeft: CONTROL_PANEL_WIDTH,
+    width: `calc(100% - ${LEFT_DRAWER_WIDTH}px)`,
+    marginLeft: LEFT_DRAWER_WIDTH,
     transition: theme.transitions.create(['margin', 'width'], {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
@@ -98,8 +98,8 @@ const useBottomDrawerStyles = makeStyles((theme) => ({
     }),
   },
   drawerShift: {
-    width: `calc(100% - ${CONTROL_PANEL_WIDTH}px)`,
-    marginLeft: CONTROL_PANEL_WIDTH,
+    width: `calc(100% - ${LEFT_DRAWER_WIDTH}px)`,
+    marginLeft: LEFT_DRAWER_WIDTH,
     transition: theme.transitions.create(['margin', 'width'], {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
@@ -118,8 +118,8 @@ const useBottomDrawerStyles = makeStyles((theme) => ({
     }),
   },
   drawerContentShift: {
-    width: `calc(100% - ${CONTROL_PANEL_WIDTH}px)`,
-    marginLeft: CONTROL_PANEL_WIDTH,
+    width: `calc(100% - ${LEFT_DRAWER_WIDTH}px)`,
+    marginLeft: LEFT_DRAWER_WIDTH,
     transition: theme.transitions.create(['margin', 'width'], {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,

--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import clsx from 'clsx';
 
-import { LEFT_DRAWER_WIDTH, BOTTOM_DRAWER_HEIGHT } from '../defaults';
+import { LEFT_DRAWER_WIDTH, BOTTOM_DRAWER_HEIGHT, BOTTOM_DRAWER_OPEN } from '../defaults';
 import { EventEmitterProxy } from '../../../model/event-emitter-proxy';
 import { NetworkEditorController } from './controller';
 import { pathwayDBLinkOut } from './links';
@@ -140,8 +140,8 @@ const useBottomDrawerStyles = makeStyles((theme) => ({
   },
 }));
 
-export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShowDrawer }) {
-  const [ open, setOpen ] = useState(false);
+export function BottomDrawer({ controller, leftDrawerOpen, isMobile, onToggle }) {
+  const [ open, setOpen ] = useState(BOTTOM_DRAWER_OPEN);
   const [ disabled, setDisabled ] = useState(true);
   const [ searchValue, setSearchValue ] = useState('');
   const [ selectedNESValues, setSelectedNESValues ] = useState([]);
@@ -308,9 +308,9 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
     };
   }, []);
 
-  const handleOpenDrawer = (b) => {
+  const handleToggle = (b) => {
     setOpen(b);
-    onShowDrawer(b);
+    onToggle?.(b);
   };
 
   const onRowSelectionChange = (row, selected, preventGotoNode = false) => {
@@ -359,7 +359,7 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
     }
   };
 
-  const shiftDrawer = controlPanelVisible && !isMobile; 
+  const shiftDrawer = leftDrawerOpen && !isMobile; 
   const magNES = controller.style ? controller.style.magNES : undefined;
   const totalPathways = disabled ? 0 : data.length;
   const filteredSelectedRows = selectedRows.filter(a => data.some(b => a.id === b.id));
@@ -370,7 +370,7 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
       className={clsx(classes.drawer, { [classes.drawerShift]: shiftDrawer })}
       variant="permanent"
       anchor="bottom"
-      open={true}
+      open={true} // It's always open here, but not expanded--don't confuse it with the 'open' state
       PaperProps={{
         style: {
           overflow: "hidden"
@@ -446,7 +446,7 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
               icon={open ? <CollapseIcon fontSize="large" /> : <ExpandIcon fontSize="large" />}
               edge="start"
               disabled={disabled}
-              onClick={() => handleOpenDrawer(!open)}
+              onClick={() => handleToggle(!open)}
             />
           </Toolbar>
           <Collapse in={open} timeout="auto" unmountOnExit>
@@ -472,8 +472,8 @@ export function BottomDrawer({ controller, controlPanelVisible, isMobile, onShow
 BottomDrawer.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController),
   isMobile: PropTypes.bool.isRequired,
-  controlPanelVisible: PropTypes.bool.isRequired,
-  onShowDrawer: PropTypes.func.isRequired,
+  leftDrawerOpen: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func,
 };
 
 //==[ ToolbarButton ]=================================================================================================

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Mousetrap from 'mousetrap';
 
-import { DEFAULT_PADDING, CONTROL_PANEL_WIDTH } from '../defaults';
+import { DEFAULT_PADDING, HEADER_HEIGHT, LEFT_DRAWER_WIDTH } from '../defaults';
 import { NetworkEditorController } from './controller';
 import TitleEditor from './title-editor';
 import { ShareMenu } from './share-panel';
@@ -371,6 +371,7 @@ function RestoreConfirmDialog({ open, onOk, onCancel }) {
 
 const useStyles = theme => ({
   appBar: {
+    minHeight: HEADER_HEIGHT,
     backgroundColor: theme.palette.background.default,
     transition: theme.transitions.create(['margin', 'width'], {
       easing: theme.transitions.easing.sharp,
@@ -378,8 +379,8 @@ const useStyles = theme => ({
     }),
   },
   appBarShift: {
-    width: `calc(100% - ${CONTROL_PANEL_WIDTH}px)`,
-    marginLeft: CONTROL_PANEL_WIDTH,
+    width: `calc(100% - ${LEFT_DRAWER_WIDTH}px)`,
+    marginLeft: LEFT_DRAWER_WIDTH,
     transition: theme.transitions.create(['margin', 'width'], {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,

--- a/src/client/components/network-editor/header.js
+++ b/src/client/components/network-editor/header.js
@@ -93,7 +93,7 @@ function getUndoButtonTitle(undoType) {
 }
 
 
-export function Header({ controller, classes, showControlPanel, isMobile, onShowControlPanel }) {
+export function Header({ controller, classes, openLeftDrawer, isMobile, onOpenLeftDrawer }) {
   const [ menuName, setMenuName ] = useState(null);
   const [ mobileMoreAnchorEl, setMobileMoreAnchorEl ] = useState(null);
   const [ anchorEl, setAnchorEl ] = useState(null);
@@ -209,7 +209,7 @@ export function Header({ controller, classes, showControlPanel, isMobile, onShow
     },
   ];
 
-  const shiftAppBar = showControlPanel && !isMobile;
+  const shiftAppBar = openLeftDrawer && !isMobile;
 
   const MobileMenu = () => {
     const isMobileMenuOpen = Boolean(mobileMoreAnchorEl);
@@ -269,12 +269,12 @@ export function Header({ controller, classes, showControlPanel, isMobile, onShow
       className={clsx(classes.appBar, { [classes.appBarShift]: shiftAppBar })}
     >
       <Toolbar variant="dense" className={classes.toolbar}>
-      {!showControlPanel && (
+      {!openLeftDrawer && (
         <ToolbarButton
           title="Genes"
           icon={<KeyboardArrowRightIcon fontSize="large" />}
           edge="start"
-          onClick={() => onShowControlPanel(!showControlPanel)}
+          onClick={() => onOpenLeftDrawer(!openLeftDrawer)}
         />
       )}
         <Box component="div" sx={{ display: { xs: 'none', sm: 'inline-block' }}}>
@@ -446,9 +446,9 @@ ToolbarDivider.propTypes = {
 Header.propTypes = {
   classes: PropTypes.object.isRequired,
   controller: PropTypes.instanceOf(NetworkEditorController),
-  showControlPanel: PropTypes.bool.isRequired,
+  openLeftDrawer: PropTypes.bool.isRequired,
   isMobile: PropTypes.bool.isRequired,
-  onShowControlPanel: PropTypes.func.isRequired,
+  onOpenLeftDrawer: PropTypes.func.isRequired,
 };
 
 RestoreConfirmDialog.propTypes = {

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { saveGeneList } from './share-panel';
 
-import { CONTROL_PANEL_WIDTH } from '../defaults';
+import { HEADER_HEIGHT, LEFT_DRAWER_WIDTH } from '../defaults';
 import { EventEmitterProxy } from '../../../model/event-emitter-proxy';
 import { NetworkEditorController } from './controller';
 import GeneListPanel from './gene-list-panel';
@@ -51,14 +51,14 @@ const sortOptions = {
 const useStyles = makeStyles((theme) => ({
   drawer: {
     background: theme.palette.background.default,
-    width: CONTROL_PANEL_WIDTH,
+    width: LEFT_DRAWER_WIDTH,
     flexShrink: 0,
     display: 'flex',
     flexFlow: 'column',
     height: '100%',
   },
   drawerPaper: {
-    width: CONTROL_PANEL_WIDTH,
+    width: LEFT_DRAWER_WIDTH,
     background: theme.palette.background.default,
     borderRight: `1px solid ${theme.palette.divider}`,
   },
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
   toolbar: {
     paddingLeft: theme.spacing(1),
     paddingRight: theme.spacing(0.5),
-    minHeight: 50,
+    minHeight: HEADER_HEIGHT,
   },
   title: {
     paddingLeft: theme.spacing(0.5),

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -92,7 +92,7 @@ const useStyles = makeStyles((theme) => ({
   grow: {
     flexGrow: 1,
   },
-  hideButton: {
+  closeButton: {
     width: 41,
     height: 41,
   },
@@ -111,7 +111,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
+const LeftDrawer = ({ controller, open, isMobile, onClose }) => {
   const [networkLoaded, setNetworkLoaded] = useState(false);
   const [geneListIndexed, setGeneListIndexed] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -332,7 +332,7 @@ const LeftDrawer = ({ controller, open, isMobile, onHide }) => {
             )}
             </Typography>
             <div className={classes.grow} />
-            <IconButton className={classes.hideButton} onClick={onHide}>
+            <IconButton className={classes.closeButton} onClick={onClose}>
               <KeyboardArrowLeftIcon fontSize="large" />
             </IconButton>
           </Toolbar>
@@ -425,7 +425,7 @@ LeftDrawer.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController),
   open: PropTypes.bool.isRequired,
   isMobile: PropTypes.bool.isRequired,
-  onHide: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default LeftDrawer;

--- a/src/client/components/network-editor/main.js
+++ b/src/client/components/network-editor/main.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 
 import { makeStyles } from '@material-ui/core/styles';
 
-import { CONTROL_PANEL_WIDTH, BOTTOM_DRAWER_HEIGHT, PATHWAY_TABLE_HEIGHT } from '../defaults';
+import { HEADER_HEIGHT, LEFT_DRAWER_WIDTH, BOTTOM_DRAWER_HEIGHT, bottomDrawerHeight } from '../defaults';
 import { EventEmitterProxy } from '../../../model/event-emitter-proxy';
 import { NetworkEditorController } from './controller';
 import LeftDrawer from './left-drawer';
@@ -34,16 +34,9 @@ const useStyles = makeStyles((theme) => ({
     }),
   },
   cyShiftX: {
-    width: `calc(100% - ${CONTROL_PANEL_WIDTH}px)`,
-    marginLeft: CONTROL_PANEL_WIDTH,
+    width: `calc(100% - ${LEFT_DRAWER_WIDTH}px)`,
+    marginLeft: LEFT_DRAWER_WIDTH,
     transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  cyShiftY: {
-    height: `calc(100% - ${BOTTOM_DRAWER_HEIGHT + PATHWAY_TABLE_HEIGHT}px)`,
-    transition: theme.transitions.create(['margin', 'height'], {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
     }),
@@ -86,7 +79,10 @@ const Main = ({ controller, showControlPanel, isMobile, onContentClick, onHideCo
     >
       <LeftDrawer open={showControlPanel} isMobile={isMobile} controller={controller} onHide={onHideControlPanel} />
       <div className={classes.background}>
-        <div className={clsx(classes.cy, { [classes.cyShiftX]: shiftXCy, [classes.cyShiftY]: shiftYCy })}>
+        <div
+          className={clsx(classes.cy, { [classes.cyShiftX]: shiftXCy })}
+          style={shiftYCy ? {height: `calc(100% - ${bottomDrawerHeight()}px)`,} : {}}
+        >
           <div id="cy" className={classes.cy} style={{ zIndex: 1, width: '100%', height: '100%' }} />
           <NetworkBackground controller={controller} />
         </div>

--- a/src/client/components/network-editor/main.js
+++ b/src/client/components/network-editor/main.js
@@ -12,6 +12,13 @@ import BottomDrawer from './bottom-drawer';
 
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    top: HEADER_HEIGHT,
+  },
   background: {
     position: 'absolute',
     left: 0,
@@ -61,23 +68,21 @@ const NetworkBackground = ({ controller }) => {
   );
 };
 
-const Main = ({ controller, showControlPanel, isMobile, onContentClick, onHideControlPanel }) => {
+const Main = ({ controller, openLeftDrawer, isMobile, onContentClick, onCloseLeftDrawer, onToggleBottomDrawer }) => {
   const [bottomDrawerOpen, setBottomDrawerOpen] = useState(false);
   const classes = useStyles();
 
-  const shiftXCy = showControlPanel && !isMobile;
+  const shiftXCy = openLeftDrawer && !isMobile;
   const shiftYCy = bottomDrawerOpen;
 
-  const onShowBottomDrawer = (open) => {
+  const handleToggleBottomDrawer = (open) => {
     setBottomDrawerOpen(open);
+    onToggleBottomDrawer?.(open);
   };
 
   return (
-    <div
-      className="network-editor-content"
-      onClick={onContentClick}
-    >
-      <LeftDrawer open={showControlPanel} isMobile={isMobile} controller={controller} onHide={onHideControlPanel} />
+    <div className={classes.root} onClick={onContentClick}>
+      <LeftDrawer open={openLeftDrawer} isMobile={isMobile} controller={controller} onClose={onCloseLeftDrawer} />
       <div className={classes.background}>
         <div
           className={clsx(classes.cy, { [classes.cyShiftX]: shiftXCy })}
@@ -89,8 +94,8 @@ const Main = ({ controller, showControlPanel, isMobile, onContentClick, onHideCo
       </div>
       <BottomDrawer
         isMobile={isMobile}
-        controlPanelVisible={showControlPanel}
-        onShowDrawer={onShowBottomDrawer}
+        leftDrawerOpen={openLeftDrawer}
+        onToggle={handleToggleBottomDrawer}
         controller={controller}
       />
     </div>
@@ -102,10 +107,11 @@ NetworkBackground.propTypes = {
 };
 Main.propTypes = {
   controller: PropTypes.instanceOf(NetworkEditorController),
-  showControlPanel: PropTypes.bool.isRequired,
+  openLeftDrawer: PropTypes.bool.isRequired,
   isMobile: PropTypes.bool.isRequired,
   onContentClick: PropTypes.func.isRequired,
-  onHideControlPanel: PropTypes.func.isRequired,
+  onCloseLeftDrawer: PropTypes.func.isRequired,
+  onToggleBottomDrawer: PropTypes.func,
 };
 
 export default Main;

--- a/src/client/components/network-editor/pathway-table.js
+++ b/src/client/components/network-editor/pathway-table.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 
 import chroma from 'chroma-js';
 import theme from '../../theme';
-import { DEFAULT_PADDING, PATHWAY_TABLE_HEIGHT } from '../defaults';
+import { DEFAULT_PADDING, pathwayTableHeight } from '../defaults';
 import { NetworkEditorController } from './controller';
 import { UpDownHBar, PValueStarRating } from './charts';
 import { REG_COLOR_RANGE } from './network-style';
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'flex-start',
     alignItems: 'center',
     width: '100%',
-    height: PATHWAY_TABLE_HEIGHT,
+    height: pathwayTableHeight(),
     padding: theme.spacing(2),
     textAlign: 'center',
   },
@@ -444,7 +444,7 @@ const PathwayTable = (
   if (!visible) {
     // Returns an empty div with the same height as the table just so the open/close animation works properly,
     // but we don't want to spend resources to build an invisible table
-    return <div style={{height: PATHWAY_TABLE_HEIGHT}} />;
+    return <div style={{height: pathwayTableHeight()}} />;
   }
 
   const handleRequestSort = (event, property) => {
@@ -559,7 +559,7 @@ const PathwayTable = (
       ref={virtuosoRef}
       data={sortedDataRef.current}
       initialTopMostItemIndex={initialTopMostItemIndex}
-      style={{height: PATHWAY_TABLE_HEIGHT, border: `1px solid ${theme.palette.divider}`}}
+      style={{height: pathwayTableHeight(), border: `1px solid ${theme.palette.divider}`}}
       components={TableComponents}
       fixedHeaderContent={() => (
         <TableRow className={classes.headerRow}>

--- a/src/styles/components/network-editor/index.css
+++ b/src/styles/components/network-editor/index.css
@@ -1,17 +1,3 @@
-.network-editor {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-}
-
-.network-editor-content {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 50px;
-}
-
 html,
 body {
   /* fixes scroll bar colour in safari */


### PR DESCRIPTION
**General information**

Associated issues: #187

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- The bottom drawer is now responsive when expanded, taking 1/3 of the content area's height (i.e. excluding the app header)--see screenshots in the comments for issue #187.
- Notice that the table has a minimum _expanded height_ of about 4 times the _collapsed height_.
- It should also be responsive when resizing the screen, but notice that there's an intentional delay (using a debounce function), because we probably don't want to too many expensive re-renderings of the table.
