### PR TITLE
Bug/217

### DIFF
--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -289,6 +289,7 @@ export class NetworkEditorController {
 
     onStop.then(() => {
       parent.scratch('_layoutRunning', false);
+      this.bus.emit('toggleExpandCollapse', parent, collapsed);
     });
 
     layout.run();
@@ -389,21 +390,27 @@ export class NetworkEditorController {
 
     const buttonLayer = layers.append('html', { stopClicks: true });
 
-    const setButtonHTML = (elem, node) => {
-      const collapsed = node.data('collapsed');
+    const setButtonHTML = (elem, parent) => {
+      const collapsed = parent.data('collapsed');
       const jsx = collapsed ? <ZoomOutMapIcon /> : <ZoomInIcon />;
       const html = ReactDOMServer.renderToStaticMarkup(jsx);
       elem.innerHTML = html;
     };
 
+    this.bus.on('toggleExpandCollapse', (parent, collapsed) => {
+      const elem = parent.scratch('buttonElem');
+      setButtonHTML(elem, parent);
+    });
+
     const createClusterToggleButton = (elem, parent) => {
       elem.classList.add('cluster-toggle-button');
       elem.style.visibility = 'hidden';
+      
+      parent.scratch('buttonElem', elem);
       setButtonHTML(elem, parent);
 
-      elem.addEventListener('click', async e => {
+      elem.addEventListener('click', async () => {
         await this.toggleExpandCollapse(parent, true);
-        setButtonHTML(elem, parent);
       });
 
       let c = 0;

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -298,26 +298,6 @@ export class NetworkEditorController {
   }
 
 
-  // TODO only tested in Chrome so far, may not work in other browsers
-  detectBubbleSetClick(svgPointFactory, position) {
-    const point = svgPointFactory.createSVGPoint();
-    point.x = position.x;
-    point.y = position.y;
-
-    const paths = this.bubbleSets ? this.bubbleSets.getPaths() : [];
-    for(const path of paths) {
-      const inside = path.node.isPointInFill(point);
-      if(inside) {
-        const parentNodes = this.cy.nodes(':parent');
-        const parent = parentNodes.filter(parent => path === parent.scratch('_bubble'));
-        if(!parent.empty()) {
-          this.toggleExpandCollapse(parent, true);
-        }
-        break;
-      }
-    }
-  }
-
   /**
    * positions is an array of objects of the form...
    * [ { id: "node-id", x:1.2, y:3.4 }, ...]
@@ -388,6 +368,7 @@ export class NetworkEditorController {
     const { cy } = this;
     const layers = cy.layers();
 
+    // Create a layer to hold the button elements
     const buttonLayer = layers.append('html', { stopClicks: true });
 
     const setButtonHTML = (elem, parent) => {
@@ -397,42 +378,50 @@ export class NetworkEditorController {
       elem.innerHTML = html;
     };
 
-    this.bus.on('toggleExpandCollapse', (parent, collapsed) => {
+    // Switch the button icon when the cluster is expanded or collapsed.
+    this.bus.on('toggleExpandCollapse', parent => {
       const elem = parent.scratch('buttonElem');
       setButtonHTML(elem, parent);
     });
 
+    // Toggle expand/collapse if user clicks direclty on the bubble.
+    cy.on('click', e => {
+      if(e.target === cy) {
+        const parent = this.getBubbleSetParent(e.position);
+        if(parent) {
+          this.toggleExpandCollapse(parent, true);
+        }
+      }
+    });
+  
+    // Detect when the user hovers over the bubble and show/hide the button.
+    let prevParent = null;
+    cy.on('mousemove', _.throttle(e => {
+      const parent = this.getBubbleSetParent(e.position);
+      if(prevParent && prevParent !== parent) {
+        const elem = prevParent.scratch('buttonElem');
+        elem.style.visibility = 'hidden';
+        prevParent = null;
+      }
+      if(parent) {
+        const elem = parent.scratch('buttonElem');
+        elem.style.visibility = 'visible';
+        prevParent = parent;
+      }
+    }, 100));
+
+    // Create a button for each cluster
     const createClusterToggleButton = (elem, parent) => {
       elem.classList.add('cluster-toggle-button');
       elem.style.visibility = 'hidden';
-      
       parent.scratch('buttonElem', elem);
+
       setButtonHTML(elem, parent);
 
+      // Toggle expand/collapse when user clicks on the button
       elem.addEventListener('click', async () => {
         await this.toggleExpandCollapse(parent, true);
       });
-
-      let c = 0;
-      const updateVisible = e => {
-        let visible = true;
-        if(e.type === 'mousedown') {
-          visible = false;
-        } else if(e.type === 'mouseup') {
-          visible = c > 0;
-        } else {
-          c += e.type === 'mouseover' ? 1 : -1;
-          visible = c > 0;
-        }
-        elem.style.visibility = visible ? 'visible' : 'hidden';
-      };
-
-      const children = parent.children();
-      const edges = children.internalEdges();
-      parent.on('mouseover mouseout', updateVisible);
-      children.on('mouseover mouseout', updateVisible);
-      edges.on('mouseover mouseout', updateVisible);
-      children.on('mousedown mouseup', updateVisible);
     };
 
     // eslint-disable-next-line no-unused-vars
@@ -464,11 +453,9 @@ export class NetworkEditorController {
     }
     
     cy.on('boxstart', () => {
-      console.log('boxstart');
       cy.pathwayNodes().addClass('box-select-enabled');
     });
     cy.on('boxend', () => {
-      console.log('boxend');
       cy.pathwayNodes().removeClass('box-select-enabled');
     });
 
@@ -524,6 +511,37 @@ export class NetworkEditorController {
       });
     });
   }
+
+
+  /**
+   * Returns the cluster parent node for the bubble path that contains the given position. 
+   * If there is more than one bubble overlapping at the given position then one of the 
+   * cluster parents is returned arbitrarily.
+   * 
+   * Note: Requires the 'svg_point_factory' that is added to the DOM by the NetworkEditor component.
+   */
+  getBubbleSetParent(position) {
+    const svgPointFactory = document.getElementById('svg_point_factory');
+    const point = svgPointFactory.createSVGPoint();
+    point.x = position.x;
+    point.y = position.y;
+
+    const paths = this.bubbleSets ? this.bubbleSets.getPaths() : [];
+    for(const path of paths) {
+      // Could check if the point is inside the bubble's bounding box first
+      // before calling isPointInFill(), it might be faster.
+      const inside = path.node.isPointInFill(point);
+      if(inside) {
+        const parentNodes = this.cy.nodes(':parent');
+        const parent = parentNodes.filter(parent => path === parent.scratch('_bubble'));
+        if(!parent.empty()) {
+          return parent;
+        }
+        break;
+      }
+    }
+  }
+
 
   /**
    * Delete the selected (i.e. :selected) elements in the graph

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -96,13 +96,6 @@ async function loadNetwork(cy, controller, id) {
     controller.savePositions();
   }, 4000));
 
-  cy.on('click', e => {
-    if(e.target === cy) {
-      const pointFactory = document.getElementById('svg_point_factory');
-      controller.detectBubbleSetClick(pointFactory, e.position);
-    }
-  });
-
   // Selecting an edge should select its nodes, but the edge itself must never be selected
   // (this makes it easier to keep the Pathways table selection consistent)
   cy.edges().on('select', evt => {


### PR DESCRIPTION
**General information**

Associated issues: #217

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

Makes the cluster toggle expand/collapse button more reliable.
- Fixes bug where the button would be hidden if you hover over an edge that goes outside the cluster.
- Fixes bug where if you expanded a cluster by clicking on the bubble the icon for the button would not update properly.
- Makes the hover detection more precise. It now detects if you are hovering over the bubble itself, not the parent node or child nodes or edges in the cluster.
- Briefly tested on chrome, safari and firefox on my machine.


