### PR TITLE
Feature/client gene list

### DIFF
--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -615,7 +615,7 @@ export class NetworkEditorController {
 
     if (res.ok) {
       const geneSet = await res.json();
-      const rankedGenes = geneSet.genes.filter(g => g.rank);
+      const rankedGenes = geneSet.genes.filter(g => _.has(g, 'rank'));
       geneSet.genes = rankedGenes;
 
       // Cache the last query

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -588,37 +588,42 @@ export class NetworkEditorController {
    */
   async fetchGeneList(geneSetNames, intersection = false) {
     geneSetNames = geneSetNames || [];
-    const nameSet = new Set(geneSetNames);
+    const result = this.searchController.queryPathwayGenes(geneSetNames, intersection);
+    console.log(result);
+    return result;
 
-    // Check local cache first
-    if (this.lastGeneSet && 
-        this.lastGeneSetIntersection === intersection && 
-        _.isEqual(this.lastGeneSetNames, nameSet)) {
-      return this.lastGeneSet;
-    }
 
-    // New query...
-    const queryParams = new URLSearchParams({ intersection });
-    const res = await fetch(`/api/${this.networkIDStr}/genesets?${queryParams}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        geneSets: geneSetNames
-      })
-    });
+    // const nameSet = new Set(geneSetNames);
 
-    if (res.ok) {
-      const geneSet = await res.json();
-      const rankedGenes = geneSet.genes.filter(g => g.rank);
-      geneSet.genes = rankedGenes;
+    // // Check local cache first
+    // if (this.lastGeneSet && 
+    //     this.lastGeneSetIntersection === intersection && 
+    //     _.isEqual(this.lastGeneSetNames, nameSet)) {
+    //   return this.lastGeneSet;
+    // }
 
-      // Cache the last query
-      this.lastGeneSetIntersection = intersection;
-      this.lastGeneSet = geneSet;
-      this.lastGeneSetNames = nameSet;
+    // // New query...
+    // const queryParams = new URLSearchParams({ intersection });
+    // const res = await fetch(`/api/${this.networkIDStr}/genesets?${queryParams}`, {
+    //   method: 'POST',
+    //   headers: { 'Content-Type': 'application/json' },
+    //   body: JSON.stringify({
+    //     geneSets: geneSetNames
+    //   })
+    // });
 
-      return geneSet;
-    }
+    // if (res.ok) {
+    //   const geneSet = await res.json();
+    //   const rankedGenes = geneSet.genes.filter(g => g.rank);
+    //   geneSet.genes = rankedGenes;
+
+    //   // Cache the last query
+    //   this.lastGeneSetIntersection = intersection;
+    //   this.lastGeneSet = geneSet;
+    //   this.lastGeneSetNames = nameSet;
+
+    //   return geneSet;
+    // }
   }
   
 

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -266,9 +266,7 @@ const LeftDrawer = ({ controller, open, isMobile, isTablet, onClose }) => {
   useEffect(() => {
     if (searchResult != null) {
       setGenes(sortGenes(searchResult, sortRef.current));
-    } else {
-      debouncedSelectionHandler();
-    }
+    } 
   }, [searchResult]);
 
   const handleGeneSetOption = async (evt) => {

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -141,8 +141,7 @@ const LeftDrawer = ({ controller, open, isMobile, isTablet, onClose }) => {
 
   const fetchGeneList = async (geneSetNames, intersection = false) => {
     const res = await controller.fetchGeneList(geneSetNames, intersection);
-    const genes = res ? res.genes : [];
-
+    const genes = res || [];
     return genes;
   };
 


### PR DESCRIPTION
**General information**

Associated issues: #222

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [x] All automated checks are passing (green check next to latest commit).
- [x] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Loads all the gene/pathway info into client memory. Two Maps are created in the SearchController. One saves the gene-to-rank mapping, the other saves the pathway-to-genes mapping. When the user selects a pathway these maps are used to compute the gene list (union or intersection).
- There should be no visible difference to how the gene list panel works. But you will notice that there is no request sent to the server when the user selects nodes.
- Fixes a bug where genes with zero rank were not being handled properly.


