### PR TITLE
Click a gene to highlight the matching nodes

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -7,6 +7,7 @@ import { useQuery } from "react-query";
 import chroma from 'chroma-js';
 import { linkoutProps } from '../defaults';
 import theme from '../../theme';
+import EventEmitterProxy from '../../../model/event-emitter-proxy';
 import { REG_COLOR_RANGE } from './network-style';
 import { NetworkEditorController } from './controller';
 import { UpDownHBar } from './charts';
@@ -356,6 +357,7 @@ const GeneListPanel = ({ controller, genes, sort, isSearch, isIntersection, isMo
   const virtuoso = useRef();
 
   const cy = controller.cy;
+  const cyEmitter = new EventEmitterProxy(cy);
   
   // Collapses and deselect a gene if it's not contained in the new 'genes' list.
   useEffect(() => {
@@ -372,6 +374,18 @@ const GeneListPanel = ({ controller, genes, sort, isSearch, isIntersection, isMo
       setResetScroll(true);
     }
   }, [genes, sort]);
+
+  useEffect(() => {
+    cyEmitter.on('tap', evt => {
+      if (evt.target === cy && selectedGene != null) {
+        // Tapping the network background should collapse the selected gene and clear the highlight
+        toggleGeneDetails(selectedGene);
+      }
+    });
+    return () => {
+      cyEmitter.removeAllListeners();
+    };
+  });
 
   useEffect(() => {
     if (genes != null && resetScroll && virtuoso && virtuoso.current) {

--- a/src/client/components/network-editor/left-drawer.js
+++ b/src/client/components/network-editor/left-drawer.js
@@ -295,6 +295,12 @@ const LeftDrawer = ({ controller, open, isMobile, isTablet, onClose }) => {
   const sortDisabled = totalGenes <= 0;
   
   const drawerVariant = isMobile || isTablet ? 'temporary' : 'persistent';
+  
+  // The 'keepMounted' property is only available when variant="temporary"
+  // (keep it mounted so the GeneListPanel component can keep its state when closed)
+  const drawerProps = {
+    ...(drawerVariant === 'temporary' && { keepMounted: true })
+  };
 
   return (
     <Drawer
@@ -302,6 +308,7 @@ const LeftDrawer = ({ controller, open, isMobile, isTablet, onClose }) => {
       variant={drawerVariant}
       anchor="left"
       open={open}
+      {...drawerProps}
       PaperProps={{
         style: {
           overflow: "hidden"


### PR DESCRIPTION
**General information**

Associated issues: #227, #221

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Uses `click` event (on a gene name) instead of `hover` to  highlight the matching Cytoscape nodes (pathways).
- Clicking/tapping the Cy background or a transparent node (i.e. a non-matching pathway) clears the highlight and collapses the previously selected gene.
- Clicking another matching node keeps the selected gene expanded and the list should auto-scroll so that gene is still visible.

**NOTICE:** All these changes should still work when the 'temporary' left-drawer is closed (tablet/mobile screen size).