### PR TITLE
Up-Down HBar handles 0.0 values properly

### DIFF
--- a/src/client/components/network-editor/charts.js
+++ b/src/client/components/network-editor/charts.js
@@ -48,9 +48,11 @@ export const UpDownHBar = ({ value, minValue, maxValue, color, bgColor, height, 
     } else if (value < 0) { // neg. value should be shifted right by the size of the pos. max. bar size
       let offset = Math.abs(minValue) / (Math.abs(minValue) + Math.abs(maxValue)) * 100;
       textStyle =  { left: `${offset + 2}%` };
-    } else { // pos. value should be shifted left by the size of the neg. max. bar size
+    } else if (value > 0) { // pos. value should be shifted left by the size of the neg. max. bar size
       let offset = Math.abs(maxValue) / (Math.abs(minValue) + Math.abs(maxValue)) * 100;
       textStyle = { right: `${offset + 2}%` };
+    } else { // ZERO value should be centered
+      textStyle = { width: '100%', textAlign: 'center' };
     }
   }
 
@@ -59,7 +61,10 @@ export const UpDownHBar = ({ value, minValue, maxValue, color, bgColor, height, 
   if (value != null) {
     data = [];
     
-    if (value < 0) {
+    if (value == 0) {
+      data.push({ value: -minValue, color: bgColor });
+      data.push({ value: maxValue, color: bgColor });
+    } else if (value < 0) {
       // Down
       if (minValue < 0 && minValue !== value) {
         data.push({ value: -(minValue - value), color: bgColor });

--- a/src/client/components/network-editor/charts.js
+++ b/src/client/components/network-editor/charts.js
@@ -52,7 +52,8 @@ export const UpDownHBar = ({ value, minValue, maxValue, color, bgColor, height, 
       let offset = Math.abs(maxValue) / (Math.abs(minValue) + Math.abs(maxValue)) * 100;
       textStyle = { right: `${offset + 2}%` };
     } else { // ZERO value should be centered
-      textStyle = { width: '100%', textAlign: 'center' };
+      let offset = Math.abs(minValue) / (Math.abs(minValue) + Math.abs(maxValue)) * 100;
+      textStyle = { left: `${offset}%`, transform: 'translateX(-50%)' };
     }
   }
 

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -483,7 +483,7 @@ const GeneListPanel = ({ controller, genes, sort, isSearch, isIntersection, isMo
                       :
                       rank != null && (
                         <UpDownHBar
-                          value={rank}
+                          value={roundedRank}
                           minValue={minRank}
                           maxValue={maxRank}
                           color={rankColor}

--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -430,11 +430,11 @@ const GeneListPanel = ({ controller, genes, sort, isSearch, isIntersection, isMo
     const loading = genes == null;
     const isSelected = !loading && selectedGene != null && selectedGene === symbol;
 
+    const roundDigits = GENE_RANK_ROUND_DIGITS;
+    const roundedRank = _.isNumber(rank) ? (Math.round(rank * Math.pow(10, roundDigits)) / Math.pow(10, roundDigits)) : NaN;
+    
     const rankColor = getRankColor(rank);
 
-    const roundDigits = GENE_RANK_ROUND_DIGITS;
-    const roundedRank = rank != null ? (Math.round(rank * Math.pow(10, roundDigits)) / Math.pow(10, roundDigits)) : 0;
-    
     // Tooltip for rank:
     const sign = roundedRank > 0 ? '+' : '';
     let reg = roundedRank > 0 ? 'up' : 'down';
@@ -481,7 +481,7 @@ const GeneListPanel = ({ controller, genes, sort, isSearch, isIntersection, isMo
                     {loading ?
                       <Skeleton variant="rect" height={CHART_HEIGHT} />
                       :
-                      rank != null && (
+                      !isNaN(roundedRank) && (
                         <UpDownHBar
                           value={roundedRank}
                           minValue={minRank}


### PR DESCRIPTION
**General information**

Associated issues: #230

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Fixes the up-down HBar so it handles `0.0` values properly
- Labels for actual zero values are now centered:
  <img width="320" alt="centered-zero-rank" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989686/08197ad1-9a77-46e5-9e7e-eea50d1af2ae">
