### PR TITLE
Fixes clearing the Genes search -- #235

### DIFF
--- a/src/client/components/network-editor/gene-list-panel.js
+++ b/src/client/components/network-editor/gene-list-panel.js
@@ -354,7 +354,7 @@ const GeneListPanel = ({
   genes,
   selectedGene,
   initialIndex = -1,
-  isSearch,
+  isSearch = false,
   isIntersection,
   isMobile,
   onGeneClick,


### PR DESCRIPTION
**General information**

Associated issues: #235

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

It's now possible again to clear the gene search by clicking the 'X' button or deleting the search text.
Also some minor refactoring.

It would be good to test these again, with and without a search result, just to make sure there are no regressions:
- selecting another pathway
- sorting (up/down)
- selecting a gene
- typing an invalid gene name (to show the 'no results' box), then clearing the search.
- etc.