### PR TITLE
Unhighlight bubbles when all their children are unhighlighted.

### DIFF
--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -184,13 +184,9 @@ export const createNetworkStyle = (cy) => {
         }
       },
       {
-        selector: 'node.unhighlighted:child',
+        selector: 'node.unhighlighted:parent',
         style: {
-          'background-color': 'white',
-          'opacity': 0.05,
-          'border-width': 1,
-          'border-color': getNodeColor,
-          'border-opacity': 1.0,
+          'label': ''
         }
       },
       {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -20,3 +20,7 @@ a {
 * {
   outline: none !important;
 }
+
+path.unhighlighted {
+  visibility: hidden;
+}


### PR DESCRIPTION
Refs #233

**General information**

Associated issues: #233

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Hides bubbles and their labels when all their children are unhighlighted. Also hides the expand/collapse buttons.
- Code also has a refactoring where the keys used for ele.scratch(...) are now declared as constants.


https://github.com/cytoscape/enrichment-map-webapp/assets/5350528/b3b0ae09-bafe-40e1-9536-42dd212662d6

