### PR TITLE
Clicking a table row no longer clears the Pathway search

### DIFF
--- a/src/client/components/network-editor/bottom-drawer.js
+++ b/src/client/components/network-editor/bottom-drawer.js
@@ -165,7 +165,8 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
   const disabledRef = useRef(true);
   disabledRef.current = disabled;
 
-  const lastSelectedRowsRef = useRef([]); // Will be used to clear the search only when selecting a node on the network
+  const lastClickedRowRef = useRef(); // Will be used to prevent clearing the search when clicking a table row
+
   const currentRowRef = useRef();
   currentRowRef.current = currentRow;
   
@@ -287,7 +288,7 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
     cyEmitter.on('select unselect', debouncedOnNetworkSelection);
     cyEmitter.on('select', evt => {
       const selId = evt.target.length === 1 ? evt.target.data('id') : null;
-      if (!lastSelectedRowsRef.current.includes(selId)) {
+      if (lastClickedRowRef.current !== selId) {
         clearSearch();
       }
     });
@@ -311,8 +312,8 @@ export function BottomDrawer({ controller, open, leftDrawerOpen, isMobile, isTab
   }, []);
 
   const onRowSelectionChange = (row, selected, preventGotoNode = false) => {
+    lastClickedRowRef.current = row.id;
     if (selected) {
-      lastSelectedRowsRef.current = selectedRows;
       cy.nodes(`[id = "${row.id}"]`).select();
       setGotoCurrentNode(!preventGotoNode);
       setCurrentRow(row);


### PR DESCRIPTION
**General information**

Associated issues: #257

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

Clicking a table row (to select or deselect it) no longer clears the _Pathway_ search.
Notice that clicking any other Cytoscape node will still clear the current pathway search.