### PR TITLE
Revised bubble/cluster behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "classnames": "^2.2.6",
         "cookie-parser": "^1.4.5",
         "cytoscape": "^3.25.0",
+        "cytoscape-automove": "^1.10.3",
         "cytoscape-bubblesets": "^3.2.0",
         "cytoscape-fcose": "^2.2.0",
         "cytoscape-layers": "^2.4.1",
@@ -7976,6 +7977,14 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-automove": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cytoscape-automove/-/cytoscape-automove-1.10.3.tgz",
+      "integrity": "sha512-Byj9RkFolphbSoZ/XAse3ch3i/5mDEwaYAy+s8iEJzbzDsnakxQ4BgaHNm9ydUqq38I3vtM6NSmRMTV2DK9QaA==",
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
       }
     },
     "node_modules/cytoscape-bubblesets": {
@@ -25561,6 +25570,12 @@
         "heap": "^0.2.6",
         "lodash": "^4.17.21"
       }
+    },
+    "cytoscape-automove": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cytoscape-automove/-/cytoscape-automove-1.10.3.tgz",
+      "integrity": "sha512-Byj9RkFolphbSoZ/XAse3ch3i/5mDEwaYAy+s8iEJzbzDsnakxQ4BgaHNm9ydUqq38I3vtM6NSmRMTV2DK9QaA==",
+      "requires": {}
     },
     "cytoscape-bubblesets": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "classnames": "^2.2.6",
     "cookie-parser": "^1.4.5",
     "cytoscape": "^3.25.0",
+    "cytoscape-automove": "^1.10.3",
     "cytoscape-bubblesets": "^3.2.0",
     "cytoscape-fcose": "^2.2.0",
     "cytoscape-layers": "^2.4.1",

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -439,7 +439,7 @@ export class NetworkEditorController {
         automoveRule.enable();
       }
 
-      const outOfBounds = nodes.some(node => {  // Check if any nodes are out of bounds
+      const outOfBounds = nodes.add(parent).some(node => {  // Check if any nodes are out of bounds
         const extent = this.cy.extent();
         const bb = node.boundingBox();
 

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -681,6 +681,12 @@ export class NetworkEditorController {
           // if (ele.isChild()) {
           //   setTimeout(() => { ele.unselect(); }, 0);
           // }
+        } else {
+          const clickedPreciseParent = this.getBubbleSetParent(evt.position);
+
+          if (!clickedPreciseParent) {
+            this.toggleExpandCollapse(parent, true);
+          }
         }
       });
 

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -554,7 +554,7 @@ export class NetworkEditorController {
     });
 
     // Toggle expand/collapse if user clicks direclty on the bubble.
-    cy.on('click', e => {
+    cy.on('tap', e => {
       if(e.target === cy) {
         const parent = this.getBubbleSetParent(e.position);
         if(parent) {
@@ -767,7 +767,7 @@ export class NetworkEditorController {
         }
       }).on('free', (evt) => {
         parent.removeClass('grabbing-collapsed-child');
-      }).on('click', (evt) => {
+      }).on('tap', (evt) => {
         parent.removeClass('grabbing-collapsed-child');
       });
     });

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -398,6 +398,7 @@ export class NetworkEditorController {
 
     const nodes = parent.children();
     const edges = nodes.internalEdges();
+    const connectedEdges = nodes.connectedEdges();
 
     const shouldAnimate = requestAnimate && nodes.size() < LARGE_CLUSTER_SIZE;
 
@@ -414,6 +415,9 @@ export class NetworkEditorController {
     const onStop = layout.promiseOn('layoutstop');
 
     parent.data('collapsed', !collapsed);
+
+    connectedEdges.data('collapsed', !collapsed);
+    this.cy.edges().not(connectedEdges).data('collapsed', collapsed);
 
     if(collapsed) {
       edges.style('visibility', 'visible');
@@ -771,6 +775,8 @@ export class NetworkEditorController {
         parent.removeClass('grabbing-collapsed-child');
       });
     });
+
+    cy.edges().data('collapsed', true);
   }
 
 

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -449,7 +449,7 @@ export class NetworkEditorController {
       if (outOfBounds && collapsed) {
         this.cy.animate({
           fit: {
-            eles: nodes,
+            eles: nodes.add(parent),
             padding: DEFAULT_PADDING
           },
           duration: 500,

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -685,7 +685,11 @@ export class NetworkEditorController {
         const dx = cluster[0].position().x - x0;
         const dy = cluster[0].position().y - y0;
 
-        if (!dragging) {
+        const collapsed = parent.data('collapsed');
+
+        if (!collapsed && !e.target.same(parent) && !cluster.allAre(':selected')) {
+          // don't apply when expanded and dragging just some children
+        } else if (!dragging) {
           draggedBubblePathSVG = bubblePath.node.cloneNode();
           bubblePath.node.parentNode.appendChild(draggedBubblePathSVG);
 

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -679,28 +679,30 @@ export class NetworkEditorController {
       let draggedBubblePathSVG;
 
       parent.on('grab', (e) => {
-        dragging = true;
-
         x0 = cluster[0].position().x;
         y0 = cluster[0].position().y;
-
-        draggedBubblePathSVG = bubblePath.node.cloneNode();
-        bubblePath.node.parentNode.appendChild(draggedBubblePathSVG);
-
-        bubblePath.remove();
       }).on('drag', (e) => {
-        if(dragging) {
-          const dx = cluster[0].position().x - x0;
-          const dy = cluster[0].position().y - y0;
+        const dx = cluster[0].position().x - x0;
+        const dy = cluster[0].position().y - y0;
 
+        if (!dragging) {
+          draggedBubblePathSVG = bubblePath.node.cloneNode();
+          bubblePath.node.parentNode.appendChild(draggedBubblePathSVG);
+
+          bubblePath.remove();
+
+          dragging = true;
+        } else {
           draggedBubblePathSVG.style.transform = `translate(${dx}px, ${dy}px)`;
         }
       }).on('free', () => {
-        dragging = false;
+        if (dragging) {
+          dragging = false;
 
-        draggedBubblePathSVG.remove();
+          draggedBubblePathSVG.remove();
 
-        bubblePath = this._createOrUpdateBubblePath(parent);
+          bubblePath = this._createOrUpdateBubblePath(parent);
+        }
       });
   
       parent.on('tap', evt => {

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -103,7 +103,7 @@ export const createNetworkStyle = (cy) => {
           'text-outline-width': 4,
           'text-outline-opacity': TEXT_OPACITY,
           'color': '#fff',
-          'z-index': 1,
+          'z-index': 2,
           'label': nodeLabel,
           'font-weight': 'bold',
           'line-height': 1.2,
@@ -172,6 +172,16 @@ export const createNetworkStyle = (cy) => {
           'haystack-radius': 0,
           'width': ele => ele.data('similarity_coefficient') * 15,
           'z-index': 1,
+          'z-compound-depth': 'bottom',
+          'z-index-compare': 'manual'
+        }
+      },
+      {
+        selector: 'edge[!collapsed]',
+        style: {
+          'z-index': 1,
+          'z-compound-depth': 'auto',
+          'z-index-compare': 'auto'
         }
       },
       {

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -188,6 +188,7 @@ export const createNetworkStyle = (cy) => {
         selector: 'node:parent:selected',
         style: {
           'border-width': 0,
+          'text-outline-color': '#fff',
         }
       },
       {

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -60,7 +60,7 @@ function getMinMaxValues(cy, attr) {
 export const nodeLabel = _.memoize(node => {
   const label = node.data('label');
   if(label)
-    return label;
+    return label.toUpperCase();
   const name = node.data('name');
   const pathway = Array.isArray(name) ? name[0] : name;
   return parsePathwayName(pathway);
@@ -91,21 +91,23 @@ export const createNetworkStyle = (cy) => {
       {
         selector: 'node',
         style: {
-          'min-zoomed-font-size': 10,
           'opacity': NODE_OPACITY,
           'border-width': 12,
           'border-opacity': 0,
           'width':  40,
           'height': 40,
-          'font-size': '8px',
+          'font-size': '10px',
           'text-valign': 'center',
           'text-wrap': 'wrap',
           'text-max-width': 80,
-          'text-outline-width': 2,
+          'text-outline-width': 4,
           'text-outline-opacity': TEXT_OPACITY,
           'color': '#fff',
           'z-index': 1,
           'label': nodeLabel,
+          'font-weight': 'bold',
+          'line-height': 1.2,
+          'text-events': 'yes',
         }
       },
       {
@@ -115,15 +117,22 @@ export const createNetworkStyle = (cy) => {
           'border-width': 0,
           'font-size': '14px',
           'text-valign':'top',
-          'text-outline-width': 0,
-          'text-outline-opacity': 0,
-          'text-opacity': 0.6,
+          'text-outline-width': 4,
+          'text-outline-opacity': 1,
+          'text-outline-color': '#fff',
+          'text-opacity': 1,
           'color': clusterTextColor,
           'text-events': 'yes',
         }
       },
       {
-        selector: 'node[NES]',
+        selector: 'node:active',
+        style: {
+          'overlay-opacity': 0.25
+        }
+      },
+      {
+        selector: 'node[NES]:childless',
         style: {
           'background-color':   getNodeColor,
           'text-outline-color': getNodeColor,
@@ -132,8 +141,20 @@ export const createNetworkStyle = (cy) => {
       {
         selector: 'node[parent][?collapsed]',
         style: {
-          'label': n => '',
-          'events': 'no'
+          'label': ''
+        }
+      },
+      {
+        selector: 'node[parent][?collapsed]',
+        style: {
+          'label': '',
+          'overlay-opacity': 0
+        }
+      },
+      {
+        selector: 'node.grabbing-collapsed-child',
+        style: {
+          'overlay-opacity': 0.25
         }
       },
       {
@@ -181,7 +202,7 @@ export const createNetworkStyle = (cy) => {
         selector: 'node.unhighlighted',
         style: {
           'opacity': 0.1,
-          'label': () => '',
+          'label': '',
           'z-index': 1,
         }
       },

--- a/src/client/components/network-editor/network-style.js
+++ b/src/client/components/network-editor/network-style.js
@@ -97,17 +97,19 @@ export const createNetworkStyle = (cy) => {
           'width':  40,
           'height': 40,
           'font-size': '10px',
-          'text-valign': 'center',
+          'text-valign': 'top',
           'text-wrap': 'wrap',
-          'text-max-width': 80,
+          'text-max-width': 120,
           'text-outline-width': 4,
-          'text-outline-opacity': TEXT_OPACITY,
-          'color': '#fff',
+          'text-outline-opacity': 1,
+          'text-outline-color': '#fff',
+          'color': '#000',
           'z-index': 2,
           'label': nodeLabel,
           'font-weight': 'bold',
           'line-height': 1.2,
           'text-events': 'yes',
+          'text-margin-y': -2
         }
       },
       {
@@ -121,7 +123,7 @@ export const createNetworkStyle = (cy) => {
           'text-outline-opacity': 1,
           'text-outline-color': '#fff',
           'text-opacity': 1,
-          'color': clusterTextColor,
+          'color': '#000',
           'text-events': 'yes',
         }
       },
@@ -134,8 +136,7 @@ export const createNetworkStyle = (cy) => {
       {
         selector: 'node[NES]:childless',
         style: {
-          'background-color':   getNodeColor,
-          'text-outline-color': getNodeColor,
+          'background-color':   getNodeColor
         }
       },
       {

--- a/src/client/components/network-editor/search-contoller.js
+++ b/src/client/components/network-editor/search-contoller.js
@@ -10,7 +10,7 @@ export function parsePathwayName(pathway) {
   if (i > 0) {
     name = name.substring(0, i);
   }
-  return name.toLowerCase().replace(/_/g, ' ');
+  return name.toUpperCase().replace(/_/g, ' ');
 }
 
 

--- a/src/client/cy-extensions.js
+++ b/src/client/cy-extensions.js
@@ -3,6 +3,7 @@ import fcose from 'cytoscape-fcose';
 import layoutUtilities from 'cytoscape-layout-utilities';
 import BubbleSets from 'cytoscape-bubblesets';
 import Layers from 'cytoscape-layers';
+import automove from 'cytoscape-automove';
 
 export const registerCytoscapeExtensions = () => {
   // Layout extensions
@@ -10,6 +11,7 @@ export const registerCytoscapeExtensions = () => {
   Cytoscape.use(layoutUtilities);
   Cytoscape.use(Layers);
   Cytoscape.use(BubbleSets);
+  Cytoscape.use(automove);
 
   // Collection extensions
   Cytoscape.use(internalEdges);


### PR DESCRIPTION
**General information**

Update the bubbles, with most of the revised behaviour.  Changes on dev.

Associated issues:

- #264

**Checklist**

Author:

- [x] One or more reviewers have been assigned.
- [ ] N/A -- Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [x] The associated GitHub issues are included (above).
- [x] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- When you click a bubble, it should show you the genes in the bubble. Basically, select the children.
- Drag anywhere on the cluster to move it.
- All uppercase labels instead of lowercase for now. It's better than lowercase, and getting everything nicely in title case requires cleaning the database.
- Bubbles shouldn't stay expanded. They should auto-close when you click away.
- When you expand, if it expands and overflows the screen it should it to screen.

The labels are easier to read:

<img width="425" alt="Screenshot 2024-03-11 at 14 14 46" src="https://github.com/cytoscape/enrichment-map-webapp/assets/989043/a06e591c-cc63-4c25-bf36-130a22076c47">

Bubbles are easy to drag:

https://github.com/cytoscape/enrichment-map-webapp/assets/989043/318ab297-f77f-4587-a80e-33e935a7a5f4

Selecting a bubble shows you the genes in it:

https://github.com/cytoscape/enrichment-map-webapp/assets/989043/93756779-1a52-4e3c-a20d-0d9214356101

Expanding fits to screen when needed:

https://github.com/cytoscape/enrichment-map-webapp/assets/989043/48865d0e-c489-42fa-be4b-c47149db3f5a





