### PR TITLE
Feature/recent networks

### DIFF
--- a/src/client/components/defaults.js
+++ b/src/client/components/defaults.js
@@ -9,7 +9,9 @@ export const RIGHT_DRAWER_WIDTH = 320;
 /** The height of the bottom drawer when collapsed */
 export const BOTTOM_DRAWER_HEIGHT = 48;
 /** Whether the bottom drawer must be open (expanded) by default */
-export const BOTTOM_DRAWER_OPEN = true; 
+export const BOTTOM_DRAWER_OPEN = true;
+
+export const NETWORK_BACKGROUND = '#ffffff';
 
 /**
  * The minimum width the header toolbar must have to show its buttons.

--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import EventEmitter from 'eventemitter3';
+import clsx from 'clsx';
 import _ from 'lodash';
 
 import { makeStyles } from '@material-ui/core/styles';
@@ -120,8 +121,8 @@ const useContentStyles = makeStyles(theme => ({
   },
   content: {
     maxHeight: 700,
-    marginTop: 0,
-    marginBottom: 0,
+    marginTop: theme.spacing(8),
+    marginBottom: theme.spacing(8),
     padding: theme.spacing(4),
     paddingTop: 0,
     paddingBottom: 0,
@@ -136,6 +137,9 @@ const useContentStyles = makeStyles(theme => ({
       padding: theme.spacing(2),
     },
   },
+  contentWithRecentNetworks: {
+    marginTop: 0,
+  },
   tagline: {
     fontWeight: 800,
     fontSize: 'clamp(1.5rem, 0.75rem + 2.5vw, 3.5rem)',
@@ -144,14 +148,14 @@ const useContentStyles = makeStyles(theme => ({
       marginTop: theme.spacing(1),
     },
     [theme.breakpoints.down('xs')]: {
-      marginTop: theme.spacing(0.5),
+      marginTop: 0,
       textAlign: 'center',
     },
   },
   description : {
     fontSize: '1rem',
     color: theme.palette.secondary.main,
-    marginTop: theme.spacing(2.5),
+    marginTop: theme.spacing(5),
     marginBottom: theme.spacing(5),
     [theme.breakpoints.down('xs')]: {
       fontSize: 'unset',
@@ -165,6 +169,9 @@ const useContentStyles = makeStyles(theme => ({
       textAlign: 'center',
       alignItems: 'center',
     },
+  },
+  hiddenSection: {
+    height: 0,
   },
 }));
 
@@ -199,11 +206,6 @@ export function Content({ recentNetworksController }) {
   const updateUploadState = (update) => setUploadState(prev => ({ ...prev, ...update }));
 
   /** Effects */
-
-  // trigger getInitialValues only on component init using useEffect
-  useEffect(() => {
-    recentNetworksController.getRecentNetworksLength(length => setShowRecentNetworks(length > 0));
-  }, []); 
 
   useEffect(() => {
     loadSampleFiles().then(setSampleFiles);
@@ -349,10 +351,14 @@ export function Content({ recentNetworksController }) {
     showNetwork(networkID);
   };
 
+  const onRecentNetworksRefresh = () => {
+    recentNetworksController.getRecentNetworksLength(length => setShowRecentNetworks(length > 0));
+  };
+
   /** Render Components */
   return (
     <div className={classNames({ [classes.root]: true, [classes.rootDropping]: droppingFile })}>
-      <Header />
+      <Header showRecentNetworks={showRecentNetworks} mobile={mobile} onClickGetStarted={onClickGetStarted} />
       <Container maxWidth="lg" disableGutters>
         <div
           className={classes.drop} 
@@ -362,15 +368,13 @@ export function Content({ recentNetworksController }) {
           onDragEnd={onDragEndUpload}
         >
           <Grid container direction="column" justifyContent="center" alignItems="center">
-          {showRecentNetworks && (
-            <Grid item className={classes.section} xs={12}>
-              <RecentNetworksList isMobile={mobile} recentNetworksController={recentNetworksController} />
+            <Grid item className={clsx(classes.section, { [classes.hiddenSection]: !showRecentNetworks })} xs={12}>
+              <RecentNetworksList isMobile={mobile} recentNetworksController={recentNetworksController} onRefresh={onRecentNetworksRefresh} />
             </Grid>
-          )}
             <Grid item>
               <Grid
                 container
-                className={classes.content}
+                className={clsx(classes.content, { [classes.contentWithRecentNetworks]: showRecentNetworks })}
                 direction={mobile ? 'column' : 'row'}
                 justifyContent="center"
                 alignItems="center"
@@ -542,7 +546,7 @@ const useHeaderStyles = makeStyles(theme => ({
   },
 }));
 
-function Header() {
+function Header({ showRecentNetworks, mobile, onClickGetStarted }) {
   const classes = useHeaderStyles();
 
   return (
@@ -560,6 +564,19 @@ function Header() {
                 </Grid>
               </Grid>
             </Grid>
+          {showRecentNetworks && !mobile && (
+            <Grid item>
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                endIcon={<NavigateNextIcon />}
+                onClick={onClickGetStarted}
+              >
+                Get Started
+              </Button>
+            </Grid>
+          )}
           </Grid>
           <div className={classes.grow} />
         </Toolbar>
@@ -567,6 +584,11 @@ function Header() {
     </AppBar>
   );
 }
+Header.propTypes = {
+  showRecentNetworks: PropTypes.bool,
+  mobile: PropTypes.bool,
+  onClickGetStarted: PropTypes.func,
+};
 
 //==[ Footer ]========================================================================================================
 

--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -364,7 +364,7 @@ export function Content({ recentNetworksController }) {
           <Grid container direction="column" justifyContent="center" alignItems="center">
           {showRecentNetworks && (
             <Grid item className={classes.section} xs={12}>
-              <RecentNetworksList isMobile={mobile} onToggle={() => {}} recentNetworksController={recentNetworksController} />
+              <RecentNetworksList isMobile={mobile} recentNetworksController={recentNetworksController} />
             </Grid>
           )}
             <Grid item>

--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -164,7 +164,6 @@ const useContentStyles = makeStyles(theme => ({
     [theme.breakpoints.down('xs')]: {
       textAlign: 'center',
       alignItems: 'center',
-      marginTop: theme.spacing(1),
     },
   },
 }));

--- a/src/client/components/home/content.js
+++ b/src/client/components/home/content.js
@@ -170,9 +170,6 @@ const useContentStyles = makeStyles(theme => ({
       alignItems: 'center',
     },
   },
-  hiddenSection: {
-    height: 0,
-  },
 }));
 
 export function Content({ recentNetworksController }) {
@@ -368,7 +365,7 @@ export function Content({ recentNetworksController }) {
           onDragEnd={onDragEndUpload}
         >
           <Grid container direction="column" justifyContent="center" alignItems="center">
-            <Grid item className={clsx(classes.section, { [classes.hiddenSection]: !showRecentNetworks })} xs={12}>
+            <Grid item className={classes.section} xs={12}>
               <RecentNetworksList isMobile={mobile} recentNetworksController={recentNetworksController} onRefresh={onRecentNetworksRefresh} />
             </Grid>
             <Grid item>

--- a/src/client/components/home/index.js
+++ b/src/client/components/home/index.js
@@ -1,21 +1,23 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import theme from '../../theme';
 import Content from './content';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import { RecentNetworksController } from '../recent-networks-controller';
 
 
-export function Home() {
+export function Home({ recentNetworksController }) {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Content />
+      <Content recentNetworksController={recentNetworksController} />
     </ThemeProvider>
   );
 }
 
 Home.propTypes = {
+  recentNetworksController: PropTypes.instanceOf(RecentNetworksController).isRequired,
 };
 
 export default Home;

--- a/src/client/components/home/recent-networks-list.js
+++ b/src/client/components/home/recent-networks-list.js
@@ -20,7 +20,6 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 
-const MAX_ITEMS = 20;
 const DEF_NETWORK_NAME = 'Untitled Network';
 /** Transparent 1 pixel PNG */
 const EMPTY_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
@@ -31,11 +30,16 @@ const useStyles = theme => ({
     whiteSpace: 'nowrap',
     boxShadow: 'none',
     border: 'none',
+    borderRadius: '0 0 8px 8px',
     marginBottom: theme.spacing(2),
     padding: theme.spacing(1, 2.75, 0, 2.75),
     [theme.breakpoints.down('xs')]: {
       padding: theme.spacing(0.5, 0.75, 0, 0.75),
     },
+  },
+  title: {
+    fontWeight: 'bold',
+    textAlign: 'center',
   },
   container: {
     display: 'grid',
@@ -48,24 +52,35 @@ const useStyles = theme => ({
     overflowY: 'auto',
     flexWrap: 'nowrap',
     webkitOverflowScrolling: 'touch',
-    padding: theme.spacing(0, 0, 1, 0),
+    padding: theme.spacing(0, 0, 1.5, 0),
     transform: 'translateZ(0)', // Promote the list into his own layer on Chrome. This cost memory but helps keeping high FPS.
   },
   paperItem: {
     display: 'inline-block',
     margin: theme.spacing(0.5),
+    padding: theme.spacing(0.5),
     cursor: 'pointer',
+    border: `2px solid ${theme.palette.background.default}`,
+    borderRadius: '8px',
+    backgroundColor: theme.palette.background.default,
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    }
   },
   paperItemSkeleton: {
     display: 'inline-block',
     margin: theme.spacing(0.5),
+    padding: theme.spacing(0.5),
     cursor: 'default',
-    border: '1px solid transparent',
+    border: `2px solid ${theme.palette.background.default}`,
+    borderRadius: '8px',
+    backgroundColor: theme.palette.background.default,
   },
   thumbnail: {
     width: 172,
     height: 148,
     objectFit: 'contain',
+    borderRadius: 4,
     [theme.breakpoints.down('xs')]: {
       width: 148,
       height: 128,
@@ -74,18 +89,14 @@ const useStyles = theme => ({
   metadata: {
     textAlign: 'left',
     margin: 0,
-    padding: theme.spacing(0.5, 0.25, 0.5, 1),
+    padding: theme.spacing(0.5, 0.25, 0.5, 0.25),
   },
   metadataSkeleton: {
     margin: 0,
     padding: '10px 2px 10px 2px',
   },
-  subtitle1: {
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  body2: {
-    maxWidth: 148,
+  name: {
+    maxWidth: 160,
     margin: 0,
     padding: 0,
     whiteSpace: 'nowrap',
@@ -134,12 +145,11 @@ export class RecentNetworksList extends Component {
     this.controller.getRecentNetworksLength((length) => {
       this.setState({
         loading: true,
-        length: Math.min(length, MAX_ITEMS),
+        length: length,
         currentItem: null,
         anchorEl: null,
       }, () => {
-        this.controller.getRecentNetworks((val) => {
-          const recentNetworks = val.slice(0, MAX_ITEMS);
+        this.controller.getRecentNetworks('opened', (recentNetworks) => {
           this.setState({
             loading: false,
             length: recentNetworks.length,
@@ -216,7 +226,7 @@ export class RecentNetworksList extends Component {
               <Box>
                 <Grid container alignItems='center' alignContent="center" justifyContent="space-between">
                   <Grid item>
-                    <Typography variant="subtitle1" gutterBottom className={classes.subtitle1}>
+                    <Typography variant="subtitle1" gutterBottom className={classes.title}>
                       Recent Networks ({ length }):
                     </Typography>
                   </Grid>
@@ -262,6 +272,21 @@ export class RecentNetworksList extends Component {
 
     const onClick = () => this.openNetwork(id, secret);
 
+    const tooltipText = () => {
+      return <>
+        <code>Last opened: { new Date(obj.opened).toLocaleString('en-US') }</code><br />
+        <code>Created:&nbsp;&nbsp;&nbsp;&nbsp; { new Date(obj.created).toLocaleString('en-US') }</code>
+      </>;
+    };
+    const lastOpenedText = () => {
+      const date = new Date(obj.opened);
+      let today = new Date();
+      if (new Date(date).setHours(0,0,0,0) == today.setHours(0,0,0,0)) { // call setHours to take the time out of the comparison
+          return date.toLocaleTimeString('en-US', { hour: "2-digit", minute: "2-digit" }); // Date equals today's date, so display only the time
+      }
+      return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+    };
+
     return (
       <Paper
         key={idx}
@@ -288,7 +313,7 @@ export class RecentNetworksList extends Component {
               <Grid item>
                 { enabled ? (
                   <Tooltip title={name}>
-                    <Typography variant="body2" className={classes.body2}>
+                    <Typography variant="body2" className={classes.name}>
                       { name }
                     </Typography>
                   </Tooltip>
@@ -300,9 +325,9 @@ export class RecentNetworksList extends Component {
                 { enabled ? (
                   <Grid container direction="row" alignItems='center' justifyContent="space-between">
                     <Grid item>
-                      <Tooltip title={'Opened ' + new Date(obj.opened).toLocaleString('en-US')}>
+                      <Tooltip title={tooltipText()}>
                         <Typography variant="caption" className={classes.caption}>
-                          { new Date(obj.opened).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) }
+                          { lastOpenedText() }
                         </Typography>
                       </Tooltip>
                     </Grid>

--- a/src/client/components/home/recent-networks-list.js
+++ b/src/client/components/home/recent-networks-list.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
+import { NETWORK_BACKGROUND } from '../defaults';
 import { RecentNetworksController } from '../recent-networks-controller';
 
 import { withStyles } from '@material-ui/core/styles';
@@ -265,7 +266,6 @@ export class RecentNetworksList extends Component {
     const name = obj.name ? obj.name : DEF_NETWORK_NAME;
     const png = obj.thumbnail ? obj.thumbnail : EMPTY_PNG;
     const imgSrc = `data:image/png;base64,${png}`;
-    const bgColor = '#ffffff'; // TODO use the network background color
     const enabled = id != null;
 
     const onClick = () => this.openNetwork(id, secret);
@@ -280,7 +280,7 @@ export class RecentNetworksList extends Component {
         <Grid container direction="column" alignItems="stretch" justifyContent="center">
           <Grid item>
             { enabled ? (
-              <img src={imgSrc} className={classes.thumbnail} style={{ background: bgColor }} />
+              <img src={imgSrc} className={classes.thumbnail} style={{ background: NETWORK_BACKGROUND }} />
             ) : (
               <Skeleton variant="rect" className={classes.thumbnail} />
             )}

--- a/src/client/components/home/recent-networks-list.js
+++ b/src/client/components/home/recent-networks-list.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 
 import { NETWORK_BACKGROUND } from '../defaults';
 import { networkURL } from '../util';
-import theme from '../../theme';
 import { RecentNetworksController } from '../recent-networks-controller';
 
 import { withStyles } from '@material-ui/core/styles';
@@ -12,7 +11,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { Box, Paper, Grid } from '@material-ui/core';
 import { Typography, Tooltip } from '@material-ui/core';
 import { Popover, MenuList, MenuItem, List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
-import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
+import { Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core';
 import { Button, IconButton } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { Snackbar, SnackbarContent } from '@material-ui/core';
@@ -45,7 +44,7 @@ const useStyles = theme => ({
   },
   title: {
     fontWeight: 'bold',
-    textAlign: 'center',
+    textAlign: 'left',
   },
   container: {
     display: 'grid',
@@ -212,7 +211,7 @@ export class RecentNetworksList extends Component {
             recentNetworks,
             currentItem: null,
             anchorEl: null,
-          });
+          }, () => this.props.onRefresh());
         });
       });
     });
@@ -572,6 +571,7 @@ export class RecentNetworksList extends Component {
 RecentNetworksList.propTypes = {
   recentNetworksController: PropTypes.instanceOf(RecentNetworksController).isRequired,
   isMobile: PropTypes.bool,
+  onRefresh: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
 };
 

--- a/src/client/components/home/recent-networks-list.js
+++ b/src/client/components/home/recent-networks-list.js
@@ -10,8 +10,9 @@ import { Box, Paper, Grid } from '@material-ui/core';
 import { Typography, Tooltip } from '@material-ui/core';
 import { Popover, MenuList, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
-import { Button, IconButton } from '@material-ui/core';
+import { Button, IconButton, Link } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
+import Collapse from '@material-ui/core/Collapse';
 
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
@@ -55,9 +56,10 @@ const useStyles = theme => ({
     cursor: 'pointer',
   },
   paperItemSkeleton: {
+    display: 'inline-block',
     margin: theme.spacing(0.5),
-    border: '1px solid transparent',
     cursor: 'default',
+    border: '1px solid transparent',
   },
   thumbnail: {
     width: 172,
@@ -207,53 +209,51 @@ export class RecentNetworksList extends Component {
     const { classes } = this.props;
 
     return (
-      <>
-        { length > 0 && (
-          <Paper variant="outlined" square className={classes.paper}>
-            <Grid container direction="column" alignItems="stretch" alignContent="stretch" justifyContent="flex-start">
-              <Grid item>
-                <Box>
-                  <Grid container alignItems='center' alignContent="center" justifyContent="space-between">
-                    <Grid item>
-                      <Typography variant="subtitle1" gutterBottom className={classes.subtitle1}>
-                        Recent Networks ({ length }):
-                      </Typography>
-                    </Grid>
-                    {/* <Grid item>
-                      <Button
-                        size='small'
-                        variant="contained"
-                        color="default"
-                        className={classes.button}
-                        disabled={loading || length <= 0}
-                        onClick={() => this.clearRecentNetworks()}
-                      >
-                        Clear
-                      </Button>
-                    </Grid> */}
+      <Collapse in={length > 0} timeout={500}>
+        <Paper variant="outlined" square className={classes.paper}>
+          <Grid container direction="column" alignItems="stretch" alignContent="stretch" justifyContent="flex-start">
+            <Grid item>
+              <Box>
+                <Grid container alignItems='center' alignContent="center" justifyContent="space-between">
+                  <Grid item>
+                    <Typography variant="subtitle1" gutterBottom className={classes.subtitle1}>
+                      Recent Networks ({ length }):
+                    </Typography>
                   </Grid>
-                </Box>
-              </Grid>
-              <Grid item className={classes.container}>
-                <Box className={classes.imageList}>
-                  { loading && length > 0 && _.times(length, (idx) =>
-                    this.renderItem({}, idx)
-                  )}
-                  { !loading && recentNetworks && recentNetworks.map((obj, idx) =>
-                    this.renderItem(obj, idx)
-                  )}
-                </Box>
-              </Grid>
-              { anchorEl && currentItem && (
-                this.renderPopover()
-              )}
-              { confirm && currentItem && (
-                this.renderConfirmationDialog()
-              )}
+                  {/* <Grid item>
+                    <Button
+                      size='small'
+                      variant="contained"
+                      color="default"
+                      className={classes.button}
+                      disabled={loading || length <= 0}
+                      onClick={() => this.clearRecentNetworks()}
+                    >
+                      Clear
+                    </Button>
+                  </Grid> */}
+                </Grid>
+              </Box>
             </Grid>
-          </Paper>
-        )}
-      </>
+            <Grid item className={classes.container}>
+              <Box className={classes.imageList}>
+                { loading && length > 0 && _.times(length, (idx) =>
+                  this.renderItem({}, idx)
+                )}
+                { !loading && recentNetworks && recentNetworks.map((obj, idx) =>
+                  this.renderItem(obj, idx)
+                )}
+              </Box>
+            </Grid>
+            { anchorEl && currentItem && (
+              this.renderPopover()
+            )}
+            { confirm && currentItem && (
+              this.renderConfirmationDialog()
+            )}
+          </Grid>
+        </Paper>
+      </Collapse>
     );
   }
 
@@ -387,7 +387,7 @@ export class RecentNetworksList extends Component {
         <DialogTitle>Delete Network?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            The network &quot;<b>{name}</b>&quot; will be permanently deleted.
+            The network &quot;<b>{name}</b>&quot; will be removed from the list.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/src/client/components/home/recent-networks-list.js
+++ b/src/client/components/home/recent-networks-list.js
@@ -1,0 +1,410 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+
+import { RecentNetworksController } from '../recent-networks-controller';
+
+import { withStyles } from '@material-ui/core/styles';
+
+import { Container, Paper, Grid } from '@material-ui/core';
+import { Typography, Tooltip } from '@material-ui/core';
+import { Popover, MenuList, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
+import { Button, IconButton } from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+
+
+const MAX_ITEMS = 25;
+const DEF_NETWORK_NAME = 'Untitled Network';
+/** Transparent 1 pixel PNG */
+const EMPTY_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+
+
+const useStyles = theme => ({
+  root: {
+    margin: 0,
+    padding: 0,
+    justifyContent: 'space-between',
+  },
+  item: {
+    margin: 0,
+    padding: 0,
+  },
+  metadata: {
+    textAlign: 'left',
+    margin: 0,
+    padding: theme.spacing(0.5, 0.25, 0.5, 1),
+  },
+  metadataSkeleton: {
+    margin: 0,
+    padding: '10px 2px 10px 2px',
+  },
+  paper: {
+    marginBottom: theme.spacing(2),
+    padding: theme.spacing(1, 0, 1, 0),
+    whiteSpace: 'nowrap',
+    boxShadow: 'none',
+  },
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'left',
+    [theme.breakpoints.down('xs')]: {
+      justifyContent: 'center',
+    },
+  },
+  paperItem: {
+    margin: theme.spacing(0.5),
+    cursor: 'pointer',
+  },
+  paperItemSkeleton: {
+    margin: theme.spacing(0.5),
+    border: '1px solid transparent',
+    cursor: 'default',
+  },
+  thumbnail: {
+    width: 172,
+    height: 148,
+    objectFit: 'contain',
+    [theme.breakpoints.down('xs')]: {
+      width: 148,
+      height: 128,
+    },
+  },
+  button: {
+    margin: 0,
+    textTransform: 'unset',
+  },
+  subtitle1: {
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  body2: {
+    maxWidth: 148,
+    margin: 0,
+    padding: 0,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    [theme.breakpoints.down('xs')]: {
+      maxWidth: 132,
+    },
+  },
+  caption: {
+    color: theme.palette.secondary.main,
+  },
+});
+
+
+export class RecentNetworksList extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.controller = this.props.recentNetworksController;
+
+    this.state = {
+      loading: false,
+      length: 0,
+      recentNetworks: null,
+      currentItem: null,
+      anchorEl: null,
+      confirm: false,  // Whether or not to show the confirmation dialog
+      confirmFn: null, // Function to be executed after the action is confirmed through the confirmation dialog
+    };
+
+    this.deleteCurrentNetwork = this.deleteCurrentNetwork.bind(this);
+  }
+
+  componentDidMount() {
+    if (!this.state.recentNetworks)
+      this.refresh();
+  }
+
+  refresh() {
+    this.controller.getRecentNetworksLength((length) => {
+      this.setState({
+        loading: true,
+        length: Math.min(length, MAX_ITEMS),
+        currentItem: null,
+        anchorEl: null,
+      }, () => {
+        this.controller.getRecentNetworks((val) => {
+          const recentNetworks = val.slice(0, MAX_ITEMS);
+          this.setState({
+            loading: false,
+            length: recentNetworks.length,
+            recentNetworks,
+            currentItem: null,
+            anchorEl: null,
+          });
+        });
+      });
+    });
+  }
+
+  openNetwork(id, secret, newTab) {
+    this.hidePopover();
+    const url = `/document/${id}`;
+    if (newTab) {
+      const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+      if (newWindow)
+        newWindow.opener = null;
+    } else {
+      location.href = url;
+    }
+  }
+
+  // clearRecentNetworks() {
+  //   const { recentNetworks } = this.state;
+
+  //   if (recentNetworks)
+  //     this.controller.clearRecentNetworks(() => this.refresh());
+  // }
+
+  async deleteCurrentNetwork() {
+    const { currentItem } = this.state;
+    if (currentItem)
+      await this.deleteNetwork(currentItem.id, true);
+  }
+
+  async deleteNetwork(id, refresh) {
+    await fetch(`/api/document/${id}`, {
+      method: 'DELETE',
+    }).then(() => {
+      this.controller.removeRecentNetwork(id, () => {
+        if (refresh)
+          this.refresh();
+      });
+    }).catch((err) => {
+      console.log(err);
+    });
+  }
+
+  showPopover(event, currentItem) {
+    event.stopPropagation();
+    this.setState({
+      anchorEl: event.currentTarget,
+      currentItem
+    });
+  }
+
+  hidePopover() {
+    this.setState({
+      currentItem: null,
+      anchorEl: null,
+    });
+  }
+
+  render() {
+    const { loading, length, recentNetworks, currentItem, anchorEl, confirm } = this.state;
+    const { classes } = this.props;
+
+    return (
+      <>
+        { length > 0 && (
+          <Paper variant="outlined" square className={classes.paper}>
+            <Grid container direction="column" alignItems="stretch" alignContent="stretch" justifyContent="flex-start" className={classes.root}>
+              <Grid item>
+                <Container>
+                  <Grid container alignItems='center' alignContent="center" justifyContent="space-between">
+                    <Grid item>
+                      <Typography variant="subtitle1" gutterBottom className={classes.subtitle1}>
+                        Recent Networks ({ length }):
+                      </Typography>
+                    </Grid>
+                    {/* <Grid item>
+                      <Button
+                        size='small'
+                        variant="contained"
+                        color="default"
+                        className={classes.button}
+                        disabled={loading || length <= 0}
+                        onClick={() => this.clearRecentNetworks()}
+                      >
+                        Clear
+                      </Button>
+                    </Grid> */}
+                  </Grid>
+                </Container>
+              </Grid>
+              <Grid item style={{ justifyContent: 'center' }}>
+                <Container className={classes.container}>
+                  { loading && length > 0 && _.times(length, (idx) =>
+                    this.renderItem({}, idx)
+                  )}
+                  { !loading && recentNetworks && recentNetworks.map((obj, idx) =>
+                    this.renderItem(obj, idx)
+                  )}
+                </Container>
+              </Grid>
+              { anchorEl && currentItem && (
+                this.renderPopover()
+              )}
+              { confirm && currentItem && (
+                this.renderConfirmationDialog()
+              )}
+            </Grid>
+          </Paper>
+        )}
+      </>
+    );
+  }
+
+  renderItem(obj, idx) {
+    const { classes } = this.props;
+
+    const id = obj.id;
+    const secret = obj.secret;
+    const name = obj.name ? obj.name : DEF_NETWORK_NAME;
+    const png = obj.thumbnail ? obj.thumbnail : EMPTY_PNG;
+    const imgSrc = `data:image/png;base64,${png}`;
+    const bgColor = '#ffffff'; // TODO use the network background color
+    const enabled = id != null;
+
+    const onClick = () => this.openNetwork(id, secret);
+
+    return (
+      <Paper
+        key={idx}
+        variant="outlined"
+        className={id ? classes.paperItem : classes.paperItemSkeleton}
+        {...(enabled && { onClick })}
+      >
+        <Grid container direction="column" alignItems="stretch" justifyContent="center" className={classes.root}>
+          <Grid item className={classes.item}>
+            { enabled ? (
+              <img src={imgSrc} className={classes.thumbnail} style={{ background: bgColor }} />
+            ) : (
+              <Skeleton variant="rect" className={classes.thumbnail} />
+            )}
+          </Grid>
+          <Grid item className={classes.item}>
+            <Grid
+              container
+              direction="column"
+              alignItems="stretch"
+              justifyContent="center"
+              className={id ? classes.metadata : classes.metadataSkeleton}
+            >
+              <Grid item className={classes.item}>
+                { enabled ? (
+                  <Tooltip title={name}>
+                    <Typography variant="body2" className={classes.body2}>
+                      { name }
+                    </Typography>
+                  </Tooltip>
+                ) : (
+                  <Skeleton variant="text" height={24} />
+                )}
+              </Grid>
+              <Grid item className={classes.item}>
+                { enabled ? (
+                  <Grid container direction="row" alignItems='center' justifyContent="space-between" className={classes.root}>
+                    <Grid item className={classes.item}>
+                      <Tooltip title={'Opened ' + new Date(obj.opened).toLocaleString('en-US')}>
+                        <Typography variant="caption" className={classes.caption}>
+                          { new Date(obj.opened).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) }
+                        </Typography>
+                      </Tooltip>
+                    </Grid>
+                    <Grid item className={classes.item}>
+                      <IconButton size="small" onClick={e => this.showPopover(e, obj)}>
+                        <MoreVertIcon />
+                      </IconButton>
+                    </Grid>
+                  </Grid>
+                ) : (
+                  <Skeleton variant="text" height={30} />
+                )}
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Paper>
+    );
+  }
+
+  renderPopover() {
+    const { currentItem, anchorEl } = this.state;
+
+    const deleteIfConfirmed = () => {
+      this.setState({
+        confirm: true,
+        confirmFn: this.deleteCurrentNetwork,
+        anchorEl: null,
+      });
+    };
+
+    return (
+      <Popover
+        id="menu-popover"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => this.hidePopover()}
+      >
+        <MenuList>
+          <MenuItem onClick={() => deleteIfConfirmed()}>
+            <ListItemIcon>
+              <DeleteForeverIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Remove" />
+          </MenuItem>
+          <MenuItem onClick={() => this.openNetwork(currentItem.id, currentItem.secret, true)}>
+            <ListItemIcon>
+              <OpenInNewIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Open in New Tab" />
+          </MenuItem>
+        </MenuList>
+      </Popover>
+    );
+  }
+
+  renderConfirmationDialog() {
+    const { confirm, confirmFn, currentItem } = this.state;
+    const name = currentItem.name ? currentItem.name : DEF_NETWORK_NAME;
+
+    const handleClose = () => {
+      this.setState({ confirm: false, confirmFn: null, currentItem: null });
+    };
+    const handleOK = async () => {
+      if (confirmFn) { await confirmFn(); }
+      handleClose();
+    };
+
+    return (
+      <Dialog
+        open={confirm}
+        onClose={handleClose}
+      >
+        <DialogTitle>Delete Network?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            The network &quot;<b>{name}</b>&quot; will be permanently deleted.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" color="primary" onClick={handleClose} >
+            Cancel
+          </Button>
+          <Button variant="contained" color="primary" autoFocus onClick={handleOK}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+RecentNetworksList.propTypes = {
+  recentNetworksController: PropTypes.instanceOf(RecentNetworksController).isRequired,
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(useStyles)(RecentNetworksList);

--- a/src/client/components/home/recent-networks-list.js
+++ b/src/client/components/home/recent-networks-list.js
@@ -6,7 +6,7 @@ import { RecentNetworksController } from '../recent-networks-controller';
 
 import { withStyles } from '@material-ui/core/styles';
 
-import { Container, Paper, Grid } from '@material-ui/core';
+import { Box, Paper, Grid } from '@material-ui/core';
 import { Typography, Tooltip } from '@material-ui/core';
 import { Popover, MenuList, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
@@ -18,47 +18,39 @@ import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 
-const MAX_ITEMS = 25;
+const MAX_ITEMS = 20;
 const DEF_NETWORK_NAME = 'Untitled Network';
 /** Transparent 1 pixel PNG */
 const EMPTY_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
 
 
 const useStyles = theme => ({
-  root: {
-    margin: 0,
-    padding: 0,
-    justifyContent: 'space-between',
-  },
-  item: {
-    margin: 0,
-    padding: 0,
-  },
-  metadata: {
-    textAlign: 'left',
-    margin: 0,
-    padding: theme.spacing(0.5, 0.25, 0.5, 1),
-  },
-  metadataSkeleton: {
-    margin: 0,
-    padding: '10px 2px 10px 2px',
-  },
   paper: {
-    marginBottom: theme.spacing(2),
-    padding: theme.spacing(1, 0, 1, 0),
     whiteSpace: 'nowrap',
     boxShadow: 'none',
-  },
-  container: {
-    display: 'flex',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'left',
+    border: 'none',
+    marginBottom: theme.spacing(2),
+    padding: theme.spacing(1, 2.75, 0, 2.75),
     [theme.breakpoints.down('xs')]: {
-      justifyContent: 'center',
+      padding: theme.spacing(0.5, 0.75, 0, 0.75),
     },
   },
+  container: {
+    display: 'grid',
+    overflow: 'hidden',
+    justifyContent: 'left',
+  },
+  imageList: {
+    display: 'flex',
+    listStyle: 'none',
+    overflowY: 'auto',
+    flexWrap: 'nowrap',
+    webkitOverflowScrolling: 'touch',
+    padding: theme.spacing(0, 0, 1, 0),
+    transform: 'translateZ(0)', // Promote the list into his own layer on Chrome. This cost memory but helps keeping high FPS.
+  },
   paperItem: {
+    display: 'inline-block',
     margin: theme.spacing(0.5),
     cursor: 'pointer',
   },
@@ -75,6 +67,15 @@ const useStyles = theme => ({
       width: 148,
       height: 128,
     },
+  },
+  metadata: {
+    textAlign: 'left',
+    margin: 0,
+    padding: theme.spacing(0.5, 0.25, 0.5, 1),
+  },
+  metadataSkeleton: {
+    margin: 0,
+    padding: '10px 2px 10px 2px',
   },
   button: {
     margin: 0,
@@ -209,9 +210,9 @@ export class RecentNetworksList extends Component {
       <>
         { length > 0 && (
           <Paper variant="outlined" square className={classes.paper}>
-            <Grid container direction="column" alignItems="stretch" alignContent="stretch" justifyContent="flex-start" className={classes.root}>
+            <Grid container direction="column" alignItems="stretch" alignContent="stretch" justifyContent="flex-start">
               <Grid item>
-                <Container>
+                <Box>
                   <Grid container alignItems='center' alignContent="center" justifyContent="space-between">
                     <Grid item>
                       <Typography variant="subtitle1" gutterBottom className={classes.subtitle1}>
@@ -231,17 +232,17 @@ export class RecentNetworksList extends Component {
                       </Button>
                     </Grid> */}
                   </Grid>
-                </Container>
+                </Box>
               </Grid>
-              <Grid item style={{ justifyContent: 'center' }}>
-                <Container className={classes.container}>
+              <Grid item className={classes.container}>
+                <Box className={classes.imageList}>
                   { loading && length > 0 && _.times(length, (idx) =>
                     this.renderItem({}, idx)
                   )}
                   { !loading && recentNetworks && recentNetworks.map((obj, idx) =>
                     this.renderItem(obj, idx)
                   )}
-                </Container>
+                </Box>
               </Grid>
               { anchorEl && currentItem && (
                 this.renderPopover()
@@ -276,15 +277,15 @@ export class RecentNetworksList extends Component {
         className={id ? classes.paperItem : classes.paperItemSkeleton}
         {...(enabled && { onClick })}
       >
-        <Grid container direction="column" alignItems="stretch" justifyContent="center" className={classes.root}>
-          <Grid item className={classes.item}>
+        <Grid container direction="column" alignItems="stretch" justifyContent="center">
+          <Grid item>
             { enabled ? (
               <img src={imgSrc} className={classes.thumbnail} style={{ background: bgColor }} />
             ) : (
               <Skeleton variant="rect" className={classes.thumbnail} />
             )}
           </Grid>
-          <Grid item className={classes.item}>
+          <Grid item>
             <Grid
               container
               direction="column"
@@ -292,7 +293,7 @@ export class RecentNetworksList extends Component {
               justifyContent="center"
               className={id ? classes.metadata : classes.metadataSkeleton}
             >
-              <Grid item className={classes.item}>
+              <Grid item>
                 { enabled ? (
                   <Tooltip title={name}>
                     <Typography variant="body2" className={classes.body2}>
@@ -303,17 +304,17 @@ export class RecentNetworksList extends Component {
                   <Skeleton variant="text" height={24} />
                 )}
               </Grid>
-              <Grid item className={classes.item}>
+              <Grid item>
                 { enabled ? (
-                  <Grid container direction="row" alignItems='center' justifyContent="space-between" className={classes.root}>
-                    <Grid item className={classes.item}>
+                  <Grid container direction="row" alignItems='center' justifyContent="space-between">
+                    <Grid item>
                       <Tooltip title={'Opened ' + new Date(obj.opened).toLocaleString('en-US')}>
                         <Typography variant="caption" className={classes.caption}>
                           { new Date(obj.opened).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) }
                         </Typography>
                       </Tooltip>
                     </Grid>
-                    <Grid item className={classes.item}>
+                    <Grid item>
                       <IconButton size="small" onClick={e => this.showPopover(e, obj)}>
                         <MoreVertIcon />
                       </IconButton>

--- a/src/client/components/network-editor/controller.js
+++ b/src/client/components/network-editor/controller.js
@@ -384,6 +384,17 @@ export class NetworkEditorController {
     } 
   }
 
+  renameNetwork(newName) {console.log("rename network: " + newName);
+    const networkName = newName != null ? newName.trim() : null;
+    this.cy.data({ name: networkName });
+  
+    fetch(`/api/${this.networkIDStr}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ networkName })
+    });
+  }
+
   async restoreNetwork() {
     const res = await fetch(`/api/${this.networkIDStr}/positions`, {
       method: 'DELETE',

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -111,6 +111,9 @@ async function loadNetwork(id, cy, controller, recentNetworksController) {
     controller.savePositions();
     recentNetworksController.updateRecentNetwork(cy);
   }, 4000));
+  cy.on('data', _.debounce(() => {
+    recentNetworksController.updateRecentNetwork(cy);
+  }, 1000));
 
   // Selecting an edge should select its nodes, but the edge itself must never be selected
   // (this makes it easier to keep the Pathways table selection consistent)

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -16,6 +16,7 @@ import Main from './main';
 import createNetworkStyle from './network-style';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import { RecentNetworksController } from '../recent-networks-controller';
 
 
 const useStyles = makeStyles(() => ({
@@ -54,7 +55,7 @@ function createCy(id) {
 /**
  * @param { NetworkEditorController } controller
  */
-async function loadNetwork(cy, controller, id) {
+async function loadNetwork(id, cy, controller, recentNetworksController) {
   console.log('Loading...');
 
   const networkPromise = fetch(`/api/${id}`);
@@ -103,10 +104,12 @@ async function loadNetwork(cy, controller, id) {
   // Make sure to call cy.fit() after the network is ready
   cy.ready(() => {
     controller.fitAndSetZoomMinMax();
+    recentNetworksController.saveRecentNetwork(cy);
   });
 
   cy.on('position remove', 'node', _.debounce(() => {
     controller.savePositions();
+    recentNetworksController.updateRecentNetwork(cy);
   }, 4000));
 
   // Selecting an edge should select its nodes, but the edge itself must never be selected
@@ -130,7 +133,7 @@ async function loadNetwork(cy, controller, id) {
 }
 
 
-export function NetworkEditor({ id }) {
+export function NetworkEditor({ id, recentNetworksController }) {
   const [ cy ] = useState(() => createCy(id));
   const [ controller ] = useState(() => new NetworkEditorController(cy));
   const [ mobile, setMobile ] = useState(() => isMobile());
@@ -158,7 +161,7 @@ export function NetworkEditor({ id }) {
   const debouncedHandleResize = _.debounce(() => handleResize(), 100);
 
   useEffect(() => {
-    loadNetwork(cy, controller, id);
+    loadNetwork(id, cy, controller, recentNetworksController);
     return () => cy.destroy();
   }, []);
 
@@ -247,6 +250,7 @@ export function Demo() {
 
 NetworkEditor.propTypes = {
   id: PropTypes.string,
+  recentNetworksController: PropTypes.instanceOf(RecentNetworksController).isRequired,
 };
 
 export default NetworkEditor;

--- a/src/client/components/network-editor/index.js
+++ b/src/client/components/network-editor/index.js
@@ -9,7 +9,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 import { BOTTOM_DRAWER_OPEN } from '../defaults';
 import theme from '../../theme';
-import { isMobile, isTablet } from './util';
+import { isMobile, isTablet } from '../util';
 import { NetworkEditorController } from './controller';
 import Main from './main';
 

--- a/src/client/components/network-editor/main.js
+++ b/src/client/components/network-editor/main.js
@@ -6,7 +6,7 @@ import chroma from 'chroma-js';
 
 import { makeStyles } from '@material-ui/core/styles';
 
-import { DEFAULT_PADDING, HEADER_HEIGHT, LEFT_DRAWER_WIDTH, BOTTOM_DRAWER_HEIGHT, bottomDrawerHeight } from '../defaults';
+import { DEFAULT_PADDING, HEADER_HEIGHT, LEFT_DRAWER_WIDTH, BOTTOM_DRAWER_HEIGHT, NETWORK_BACKGROUND, bottomDrawerHeight } from '../defaults';
 import { EventEmitterProxy } from '../../../model/event-emitter-proxy';
 import { NetworkEditorController } from './controller';
 import { Header } from './header';
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     right: 0,
     top: 0,
     bottom: 0,
-    background: '#fff',
+    background: NETWORK_BACKGROUND,
   },
   cy: {
     position: 'absolute',
@@ -82,7 +82,7 @@ const useStyles = makeStyles((theme) => ({
 
 
 const NetworkBackground = ({ controller }) => {
-  const [ bgColor, setBgColor ] = useState('white');
+  const [ bgColor, setBgColor ] = useState(NETWORK_BACKGROUND);
 
   const busProxy = new EventEmitterProxy(controller.bus);
 

--- a/src/client/components/network-editor/title-editor.js
+++ b/src/client/components/network-editor/title-editor.js
@@ -6,18 +6,6 @@ import { NetworkEditorController } from './controller';
 import { Tooltip, InputBase } from '@material-ui/core';
 
 
-function renameNetwork(controller, newName) {
-  const networkName = newName != null ? newName.trim() : null;
-  controller.cy.data({ name: networkName });
-
-  fetch(`/api/${controller.networkIDStr}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ networkName })
-  });
-}
-
-
 /**
  * The network title editor. Shows and edits the attribute `cy.data('name')`.
  * - **ENTER** key or `blur()`: Commits the changes and renames the network.
@@ -55,7 +43,7 @@ export function TitleEditor({ controller, disabled }) {
   const handleNetworkNameBlur = () => {
     const newName = input.value;
     if (newName !== networkName) {
-      renameNetwork(controller, newName);
+      controller.renameNetwork(newName);
     }
   };
 

--- a/src/client/components/recent-networks-controller.js
+++ b/src/client/components/recent-networks-controller.js
@@ -15,25 +15,30 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
   constructor(bus) {
     /** @type {EventEmitter} */
     this.bus = bus || new EventEmitter();
+
+    LocalForage.config({
+      name    : 'EM-Web',
+      version : 1.0,
+    });
   }
 
-   saveRecentNetwork({ secret, cy }) {
+   saveRecentNetwork(cy) {
     const id = cy.data('id');
     const now = new Date();
     const opened = now.getTime();
-    const value = this._localStorageValue({ secret, opened: opened, cy });
+    const value = this._localStorageValue({ opened: opened, cy });
     
     LocalForage.setItem(id, value).catch((err) => {
       console.log(err);
     });
   }
 
-  updateRecentNetwork({ secret, cy }) {
+  updateRecentNetwork(cy) {
     const id = cy.data('id');
    
     LocalForage.getItem(id).then((val) => {
       if (val) {
-        const newValue = this._localStorageValue({ secret, opened: val.opened, cy });
+        const newValue = this._localStorageValue({ opened: val.opened, cy });
         
         LocalForage.setItem(id, newValue).catch((err) => {
           console.log(err);
@@ -86,7 +91,7 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
     });
   }
 
-  _localStorageValue({ secret, opened, cy }) {
+  _localStorageValue({ opened, cy }) {
     const name = cy.data('name');
     const now = new Date();
     const modified = now.getTime();
@@ -95,11 +100,10 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
       maxWidth: NETWORK_THUMBNAIL_WIDTH,
       maxHeight: NETWORK_THUMBNAIL_HEIGHT,
       full: true,
-      bg: '#ffffff' // TODO use network BG color
+      bg: '#ffffff', // TODO use network BG color
     });
 
     return {
-      secret,
       name,
       thumbnail,
       opened: opened ? opened : modified,

--- a/src/client/components/recent-networks-controller.js
+++ b/src/client/components/recent-networks-controller.js
@@ -2,8 +2,11 @@ import EventEmitter from 'eventemitter3';
 import LocalForage from 'localforage';
 import { NETWORK_BACKGROUND } from './defaults';
 
+
+const MAX_ITEMS = 20;
 const NETWORK_THUMBNAIL_WIDTH = 344;
 const NETWORK_THUMBNAIL_HEIGHT = 344;
+
 
 /**
  * @property {EventEmitter} bus The event bus that the controller emits on after every operation
@@ -23,15 +26,39 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
     });
   }
 
-   saveRecentNetwork(cy) {
+   async saveRecentNetwork(cy) {
     const id = cy.data('id');
-    const now = new Date();
-    const opened = now.getTime();
-    const value = this._localStorageValue({ opened: opened, cy });
-    
-    LocalForage.setItem(id, value).catch((err) => {
-      console.log(err);
-    });
+    let created;
+    const item = await LocalForage.getItem(id);
+    if (item != null) {
+      // This network already exists
+      created = item.created;
+    }
+    const keys = await LocalForage.keys();
+    const index = keys.indexOf(id);
+    if (index >= 0) {
+      // This network already exists
+      keys.splice(index, 1); // remove the current key from the list before we check the max length
+    }
+
+    const value = this._localStorageValue({ created: created, cy });
+
+    if (keys.length < MAX_ITEMS) {
+      // Just add the new item
+      LocalForage.setItem(id, value).catch((err) => {
+        console.log(err);
+      });
+    } else {
+      this.getRecentNetworks('created', (list) => {
+        // Remove the last item before adding the new one
+        const lastItem = list[list.length - 1];
+        LocalForage.removeItem(lastItem.id).then(() => {
+          LocalForage.setItem(id, value);
+        }).catch((err) => {
+          console.log(err);
+        });
+      });
+    }
   }
 
   updateRecentNetwork(cy) {
@@ -39,7 +66,7 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
    
     LocalForage.getItem(id).then((val) => {
       if (val) {
-        const newValue = this._localStorageValue({ opened: val.opened, cy });
+        const newValue = this._localStorageValue({ created: val.created, cy });
         
         LocalForage.setItem(id, newValue).catch((err) => {
           console.log(err);
@@ -50,13 +77,13 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
     });
   }
 
-  getRecentNetworks(callback) {
+  getRecentNetworks(sortByField, callback) {
     const nets = [];
 
     LocalForage.iterate((val, id) => {
       nets.push({ id, ...val });
     }).then(() => {
-      nets.sort((o1, o2) => o2.opened - o1.opened); // Sort by 'opened' date
+      nets.sort((o1, o2) => o2[sortByField] - o1[sortByField]); // Usually sort by 'opened' or 'created' date
       
       if (callback)
         callback(nets);
@@ -92,10 +119,9 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
     });
   }
 
-  _localStorageValue({ opened, cy }) {
+  _localStorageValue({ created, cy }) {
     const name = cy.data('name');
-    const now = new Date();
-    const modified = now.getTime();
+    const now = new Date().getTime();
     const thumbnail = cy.png({
       output: 'base64',
       maxWidth: NETWORK_THUMBNAIL_WIDTH,
@@ -107,8 +133,8 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
     return {
       name,
       thumbnail,
-      opened: opened ? opened : modified,
-      modified,
+      created: created ? created : now,
+      opened: now,
     };
   }
 }

--- a/src/client/components/recent-networks-controller.js
+++ b/src/client/components/recent-networks-controller.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import LocalForage from 'localforage';
+import { NETWORK_BACKGROUND } from './defaults';
 
 const NETWORK_THUMBNAIL_WIDTH = 344;
 const NETWORK_THUMBNAIL_HEIGHT = 344;
@@ -100,7 +101,7 @@ const NETWORK_THUMBNAIL_HEIGHT = 344;
       maxWidth: NETWORK_THUMBNAIL_WIDTH,
       maxHeight: NETWORK_THUMBNAIL_HEIGHT,
       full: true,
-      bg: '#ffffff', // TODO use network BG color
+      bg: NETWORK_BACKGROUND,
     });
 
     return {

--- a/src/client/components/svg-icons.js
+++ b/src/client/components/svg-icons.js
@@ -295,6 +295,14 @@ ClusterIcon.propTypes = {
   color2: PropTypes.string.isRequired,
 };
 
+export function ContentCopyIcon(props) {
+  return (
+    <SvgIcon viewBox="0 -960 960 960" {...props}>
+      <path d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"/>
+    </SvgIcon>
+  );
+}
+
 export function DownloadIcon(props) {
   return (
     <SvgIcon viewBox="0, 0, 64, 64" {...props}>

--- a/src/client/components/util.js
+++ b/src/client/components/util.js
@@ -1,4 +1,4 @@
-import theme from '../../theme';
+import theme from '../theme';
 
 
 export function isMobile() {
@@ -15,4 +15,8 @@ export function delay(millis) {
 
 export function stringToBlob(str) {
   return new Blob([str], { type: 'text/plain;charset=utf-8' });
+}
+
+export function networkURL(id) {
+  return `${window.location.origin}/document/${id}`;
 }

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -2,8 +2,11 @@ import React from 'react';
 import _ from 'lodash';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import PageNotFound from './components/page-not-found';
+import { RecentNetworksController } from './components/recent-networks-controller';
 import { Home } from './components/home';
 import { NetworkEditor } from './components/network-editor';
+
+const recentNetworksController = new RecentNetworksController();
 
 export const Router = () => (
   <BrowserRouter>
@@ -12,13 +15,13 @@ export const Router = () => (
         path='/'
         exact
         render={(props) => (
-          <Home {...props} />
+          <Home {...props} recentNetworksController={recentNetworksController} />
         )}
       />
       <Route
         path='/document/:id/:secret'
         render={(props) => (
-          <NetworkEditor {...props} />
+          <NetworkEditor {...props} recentNetworksController={recentNetworksController} />
         )}
       />
       <Route
@@ -28,7 +31,7 @@ export const Router = () => (
           const full = params['full'] === 'true';
           const id = _.get(props, ['match', 'params', 'id'], _.get(props, 'id'));
           const secret = _.get(props, ['match', 'params', 'secret'], _.get(props, 'secret'));
-          return <NetworkEditor id={id} secret={secret} full={full} />;
+          return <NetworkEditor id={id} secret={secret} full={full} recentNetworksController={recentNetworksController} />;
         }}
       />
       <Route status={404} exact component={PageNotFound} />


### PR DESCRIPTION
**General information**

Associated issues: #282

**Checklist**

Author:

- [X] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [X] The associated GitHub issues are included (above).
- [X] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Adds a list of recent networks to the Home page (uses the browser's local storage).
- It allow a maximum of 20 entries--after that, any new network will replace the oldest entry in the local storage.
- The list has a popup menu with these options:
  - **Share:** for now, it just copies all the links to the clipboard--e.g.:
    ```
    Demo Network 2	https://emdev.baderlab.net/document/f773a7fc-31a6-4f58-9a60-133cad96e568
    Demo 3	https://emdev.baderlab.net/document/044f5cce-ec09-4642-9580-bd51432832b9
    Demo Network	https://emdev.baderlab.net/document/72f6970c-693d-4496-bfd7-fa993a76741f
    GSE129943_rsem_counts_ENS_expr	https://emdev.baderlab.net/document/1060dbad-36b9-4e18-b33f-e189ce664e72
    ```
    - (*) We probably want to change this to also send an email with the links--see #261.
  - **Clear List:** removes the entries from the local store (it doesn't actually delete any network from the DB)
- Each entry has a popup menu with these options:
  - **Remove:** removes the network key/value from the local storage.
  - **Open in New Tab**: notice that clicking the network item itself opens it in the same tab, so you may find this option redundant.
