### PR TITLE
Feature/report

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -10,3 +10,4 @@ FGSEA_PRERANKED_SERVICE_URL=https://fgseadev.baderlab.net/v1/preranked
 FGSEA_RNASEQ_SERVICE_URL=https://fgseadev.baderlab.net/v1/rnaseq
 EM_SERVICE_URL=https://emjavadev.baderlab.net/v1
 BRIDGEDB_URL=https://webservice.bridgedb.org
+REPORT_SECRET=baderlab

--- a/.env.local
+++ b/.env.local
@@ -10,3 +10,4 @@ FGSEA_PRERANKED_SERVICE_URL=http://localhost:8000/preranked
 FGSEA_RNASEQ_SERVICE_URL=http://localhost:8000/rnaseq
 EM_SERVICE_URL=http://localhost:8080/v1
 BRIDGEDB_URL=https://webservice.bridgedb.org
+REPORT_SECRET=baderlab

--- a/src/client/components/network-editor/export-controller.js
+++ b/src/client/components/network-editor/export-controller.js
@@ -25,6 +25,7 @@ const Path = {
   DATA_ENRICH:   'data/enrichment_results.txt',
   DATA_RANKS:    'data/ranks.txt',
   DATA_GENESETS: 'data/gene_sets.gmt',
+  DATA_JSON:     'data/network.json',
   README:        'README.md'
 };
 
@@ -60,6 +61,7 @@ export class ExportController {
     const blob2 = await this._createNetworkImageBlob(ImageSize.LARGE);
     const blob3 = await this._createNetworkPDFBlob();
     const blob4 = await this._createSVGLegendBlob();
+    // const blob5 = await this._createNetworkJSONBlob();
     const files = await filesPromise;
     const readme = createREADME(this.controller);
   
@@ -69,6 +71,7 @@ export class ExportController {
     zip.file(Path.IMAGE_LARGE,   blob2);
     zip.file(Path.IMAGE_PDF,     blob3);
     zip.file(Path.IMAGE_LEGEND,  blob4);
+    // zip.file(Path.DATA_JSON,     blob5);
     zip.file(Path.DATA_ENRICH,   files[0]);
     zip.file(Path.DATA_RANKS,    files[1]);
     zip.file(Path.DATA_GENESETS, files[2]);
@@ -145,6 +148,16 @@ export class ExportController {
     combinedCtx.drawImage(svgCanvas, 0, 0);
   
     const blob = await combinedCanvas.convertToBlob();
+    return blob;
+  }
+
+  async _createNetworkJSONBlob() {
+    const { cy } = this.controller;
+    const json = cy.json();
+    const blob = new Blob(
+      [ JSON.stringify(json, null, 2) ], {
+      type: 'text/plain'
+    });
     return blob;
   }
 

--- a/src/client/components/network-editor/pathway-table.js
+++ b/src/client/components/network-editor/pathway-table.js
@@ -244,7 +244,7 @@ const linkoutProps = { target: "_blank",  rel: "noreferrer", underline: "hover" 
 const DEF_ORDER = 'desc';
 const DEF_ORDER_BY = 'nes';
 
-const descendingComparator = (a, b, orderBy) => {
+export const descendingComparator = (a, b, orderBy) => {
   // null values come last in ascending!
   if (a[orderBy] == null) {
     return -1;
@@ -261,7 +261,7 @@ const descendingComparator = (a, b, orderBy) => {
   return 0;
 };
 
-const getComparator = (order, orderBy) => {
+export const getComparator = (order, orderBy) => {
   return order === 'desc'
     ? (a, b) => descendingComparator(a, b, orderBy)
     : (a, b) => -descendingComparator(a, b, orderBy);

--- a/src/client/components/network-editor/pathway-table.js
+++ b/src/client/components/network-editor/pathway-table.js
@@ -245,17 +245,22 @@ const DEF_ORDER = 'desc';
 const DEF_ORDER_BY = 'nes';
 
 export const descendingComparator = (a, b, orderBy) => {
+  const aVal = a[orderBy], bVal = b[orderBy];
+
   // null values come last in ascending!
-  if (a[orderBy] == null) {
+  if (aVal == null) {
     return -1;
   }
-  if (b[orderBy] == null) {
+  if (bVal == null) {
     return 1;
   }
-  if (b[orderBy] < a[orderBy]) {
+  if(typeof aVal === 'string' && typeof bVal === 'string') {
+    return aVal.localeCompare(bVal, undefined, { sensitivity: 'accent' });
+  }
+  if (bVal < aVal) {
     return -1;
   }
-  if (b[orderBy] > a[orderBy]) {
+  if (bVal > aVal) {
     return 1;
   }
   return 0;

--- a/src/client/components/report/index.js
+++ b/src/client/components/report/index.js
@@ -6,7 +6,7 @@ import { currentTheme } from '../../theme';
 import Report from './report';
 
 
-export function ReportHome() {
+export function ReportHome({ secret }) {
   const [ theme, setTheme ] = useState(currentTheme);
 
   useEffect(() => {
@@ -22,12 +22,13 @@ export function ReportHome() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Report />
+      <Report secret={secret} />
     </ThemeProvider>
   );
 }
 
 ReportHome.propTypes = {
+  secret: PropTypes.string,
 };
 
 export default ReportHome;

--- a/src/client/components/report/index.js
+++ b/src/client/components/report/index.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { ThemeProvider } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { currentTheme } from '../../theme';
+import Report from './report';
+
+
+export function ReportHome() {
+  const [ theme, setTheme ] = useState(currentTheme);
+
+  useEffect(() => {
+    // Listen for changes in the user's theme preference
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleThemeChange = () => setTheme(currentTheme());
+    mediaQuery.addEventListener('change', handleThemeChange);
+    return () => {
+      mediaQuery.removeEventListener('change', handleThemeChange);
+    };
+  }, []);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Report />
+    </ThemeProvider>
+  );
+}
+
+ReportHome.propTypes = {
+};
+
+export default ReportHome;

--- a/src/client/components/report/report.js
+++ b/src/client/components/report/report.js
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import { getComparator } from '../network-editor/pathway-table';
+import { Select, MenuItem } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+
+const useStyles = makeStyles((theme) => ({
+  orderBy: {
+    margin: theme.spacing(1),
+    minWidth: 200,
+  },
+  order: {
+    margin: theme.spacing(1),
+    minWidth: 120,
+  },
+}));
+
+
+export function Report() {
+  const classes = useStyles();
+  const [ report, setReport ] = useState(null);
+  const [ order, setOrder] = useState('desc');
+  const [ orderBy, setOrderBy ] = useState('creationTime');
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/report/count').then(res => res.json()),
+      fetch('/api/report/networks').then(res => res.json())
+    ])
+    .then(([ counts, networks ]) => {
+      const report = { counts, networks };
+      console.log('report', report);
+      setReport(report);
+    })
+    .catch((error) => console.log(error));
+  }, []);
+
+
+  if(!report) {
+    return <div> Loading... </div>;
+  }
+
+  const comparator = getComparator(order, orderBy);
+  const sortedNetworks = report.networks.sort(comparator);
+
+  return <div>
+    <h1>EnrichmentMap:RNA-Seq - Usage Report</h1>
+    <h3>Demo Networks: {report.counts.demo}</h3>
+    <h3>User Created Networks ({report.counts.user}):</h3>
+    <div style={{"float":"right"}} >
+      Sort:
+      &nbsp;&nbsp;
+      <Select value={orderBy} onChange={(event) => setOrderBy(event.target.value)} className={classes.orderBy}>
+        <MenuItem value="networkName">Name</MenuItem>
+        <MenuItem value="creationTime">Creation Time</MenuItem>
+        <MenuItem value="lastAccessTime">Last Accessed Time</MenuItem>
+      </Select>
+      &nbsp;
+      <Select value={order} onChange={(event) => setOrder(event.target.value)} className={classes.order}>
+        <MenuItem value="desc">Desc</MenuItem>
+        <MenuItem value="asc">Asc</MenuItem>
+      </Select>
+    </div>
+    <br></br>
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell><b>Network Name</b></TableCell>
+            <TableCell align="right"><b>Nodes</b></TableCell>
+            <TableCell align="right"><b>Edges</b></TableCell>
+            <TableCell align="right"><b>Type</b></TableCell>
+            <TableCell align="right"><b>Creation Time</b></TableCell>
+            <TableCell align="right"><b>Last Access Time</b></TableCell>
+            <TableCell align="right"><b>Open</b></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedNetworks.map(network => {
+            const createTime = new Date(network.creationTime).toLocaleString('en-CA');
+            const accessTime = new Date(network.lastAccessTime).toLocaleString('en-CA');
+            return (
+              <TableRow
+                key={network._id}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+              >
+                <TableCell component="th" scope="row">{network.networkName}</TableCell>
+                <TableCell align="right">{network.nodeCount}</TableCell>
+                <TableCell align="right">{network.edgeCount}</TableCell>
+                <TableCell align="right">{network.inputType}</TableCell>
+                <TableCell align="right">{createTime}</TableCell>
+                <TableCell align="right">{accessTime}</TableCell>
+                <TableCell align="right"><a href={`/document/${network._id}`} target="_blank" rel = "noopener noreferrer">open</a></TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  </div>;
+}
+
+export default Report;

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -5,6 +5,7 @@ import PageNotFound from './components/page-not-found';
 import { RecentNetworksController } from './components/recent-networks-controller';
 import { Home } from './components/home';
 import { NetworkEditor } from './components/network-editor';
+import { ReportHome } from './components/report';
 
 const recentNetworksController = new RecentNetworksController();
 
@@ -36,6 +37,12 @@ export function Router() {
         exact
         render={(props) => (
           <Home {...props} recentNetworksController={recentNetworksController} />
+        )}
+      />
+      <Route
+        path='/report'
+        render={(props) => (
+          <ReportHome {...props} />
         )}
       />
       <Route

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -40,10 +40,11 @@ export function Router() {
         )}
       />
       <Route
-        path='/report'
-        render={(props) => (
-          <ReportHome {...props} />
-        )}
+        path='/report/:secret'
+        render={(props) => {
+          const secret = _.get(props, ['match', 'params', 'secret'], _.get(props, 'secret'));
+          return <ReportHome secret={secret} />;
+        }}
       />
       <Route
         path='/document/:id/:secret'

--- a/src/server/datastore.js
+++ b/src/server/datastore.js
@@ -752,6 +752,51 @@ class Datastore {
     return cursor;
   }
 
+
+  async getNetworkCounts() {
+    const result = await this.db
+      .collection(NETWORKS_COLLECTION)
+      .aggregate([
+        { $facet: {
+          'user': [
+            { $match: { demo: { $ne: true } }},
+            { $count: 'total' }
+          ],
+          'demo': [
+            { $match: { demo: true }},
+            { $count: 'total' }
+          ],
+        }},
+        { $project: {
+          "user": { $arrayElemAt: ["$user.total", 0] },
+          "demo": { $arrayElemAt: ["$demo.total", 0] },
+        }}
+      ]).toArray();
+    
+    return result[0];
+  }
+
+
+  async getNetworkStatsCursor() {
+    const cursor = await this.db
+      .collection(NETWORKS_COLLECTION)
+      .aggregate([
+        { $match: { demo: { $ne: true } }},
+        { $project: { 
+          networkName: 1,
+          creationTime: 1,
+          lastAccessTime: 1,
+          geneSetCollection: 1,
+          inputType: 1,
+          nodeCount: { $size: '$network.elements.nodes' },
+          edgeCount: { $size: '$network.elements.edges' }
+        }}
+    ]);
+    
+    return cursor;
+  }
+
+
 }
 
 const ds = new Datastore(); // singleton

--- a/src/server/env.js
+++ b/src/server/env.js
@@ -14,6 +14,7 @@ export const LOG_LEVEL = process.env.LOG_LEVEL;
 export const BASE_URL = process.env.BASE_URL;
 export const UPLOAD_LIMIT = process.env.UPLOAD_LIMIT;
 export const TESTING = ('' + process.env.TESTING).toLowerCase() === 'true';
+export const REPORT_SECRET = process.env.REPORT_SECRET;
 
 // Service config
 export const FGSEA_PRERANKED_SERVICE_URL = process.env.FGSEA_PRERANKED_SERVICE_URL;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -21,6 +21,7 @@ import indexRouter from './routes/index.js';
 import apiRouter from './routes/api/index.js';
 import createRouter, { createRouterErrorHandler } from './routes/api/create.js';
 import exportRouter from './routes/api/export.js';
+import reportRouter from './routes/api/report.js';
 
 import Datastore, { GMT_2 } from './datastore.js';
 
@@ -108,6 +109,7 @@ app.use('/', indexRouter);
 app.use('/api', apiRouter);
 app.use('/api/create', createRouter);
 app.use('/api/export', exportRouter);
+app.use('/api/report', reportRouter);
 
 // The error handler must be before any other error middleware and after all controllers
 if (SENTRY) {

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -231,7 +231,7 @@ http.delete('/:netid/positions', async function(req, res, next) {
 });
 
 
-async function writeCursorToResult(cursor, res) {
+export async function writeCursorToResult(cursor, res) {
   res.write('[');
   if(await cursor.hasNext()) {
     const obj = await cursor.next();

--- a/src/server/routes/api/report.js
+++ b/src/server/routes/api/report.js
@@ -1,12 +1,20 @@
 import Express from 'express';
 import Datastore from '../../datastore.js';
 import { writeCursorToResult } from './index.js';
+import { REPORT_SECRET } from '../../env.js';
 
 const http = Express.Router();
 
 // Return enrichment results in TSV format
-http.get('/count', async function(req, res, next) {
+http.get(`/count/:secret`, async function(req, res, next) {
+  
   try {
+    const { secret } = req.params;
+    if(secret !== REPORT_SECRET) {
+      res.sendStatus(404);
+      return;
+    }
+
     const counts = await Datastore.getNetworkCounts();
     res.send(JSON.stringify(counts));
 
@@ -16,8 +24,14 @@ http.get('/count', async function(req, res, next) {
 });
 
 // Return enrichment results in TSV format
-http.get('/networks', async function(req, res, next) {
+http.get(`/networks/:secret`, async function(req, res, next) {
   try {
+    const { secret } = req.params;
+    if(secret !== REPORT_SECRET) {
+      res.sendStatus(404);
+      return;
+    }
+
     const cursor = await Datastore.getNetworkStatsCursor();
     await writeCursorToResult(cursor, res);
     cursor.close();

--- a/src/server/routes/api/report.js
+++ b/src/server/routes/api/report.js
@@ -1,0 +1,32 @@
+import Express from 'express';
+import Datastore from '../../datastore.js';
+import { writeCursorToResult } from './index.js';
+
+const http = Express.Router();
+
+// Return enrichment results in TSV format
+http.get('/count', async function(req, res, next) {
+  try {
+    const counts = await Datastore.getNetworkCounts();
+    res.send(JSON.stringify(counts));
+
+  } catch(err) {
+    next(err);
+  }
+});
+
+// Return enrichment results in TSV format
+http.get('/networks', async function(req, res, next) {
+  try {
+    const cursor = await Datastore.getNetworkStatsCursor();
+    await writeCursorToResult(cursor, res);
+    cursor.close();
+
+  } catch(err) {
+    next(err);
+  } finally {
+    res.end();
+  }
+});
+
+export default http;


### PR DESCRIPTION
**General information**

Associated issues: #299 

**Checklist**

Author:

- [ ] One or more reviewers have been assigned.
- [ ] Automated tests have been included in this pull request, if possible, for the new feature(s) or bug fix.
- [ ] The associated GitHub issues are included (above).
- [ ] Notes have been included (below).

Reviewers:

- [ ] All automated checks are passing (green check next to latest commit).
- [ ] At least one reviewer has signed off on the pull request.  Reviewers have two business days to review the pull request, after which the author may merge in the pull request unilaterally.


**Notes**

- Adds endpoints on the server that return JSON info for a report.
- Adds a page on the client that shows a basic report.
- Security: 
  - A secret key must be provided as part of the URL.
  - This key is configured by an environment variable on the server.
  - The default value for the key is 'baderlab'
  - To access the report on a local instance go to `localhost:3000/report/baderlab`
  - On the prod server it will be `enrichmentmap.org/report/long-uuid-string`
- The UI is very basic for now, it just lists out all the non-demo networks on the server. For each network there is a link that opens the network.

<img width="897" alt="Screenshot 2024-07-04 at 10 04 56 AM" src="https://github.com/cytoscape/enrichment-map-webapp/assets/5350528/0d03f3e3-baaa-49e4-ba36-1a5196fe2979">

